### PR TITLE
Generate privacy policy as HTML snippet

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Save built add-on
         uses: actions/upload-artifact@v2
         with:
-          name: dist_web-ext
-          path: dist/web-ext
+          name: dist
+          path: dist
           retention-days: 30
   release:
     runs-on: ubuntu-20.04
@@ -45,12 +45,13 @@ jobs:
       - name: Download built add-on for release
         uses: actions/download-artifact@v2
         with:
-          name: dist_web-ext
-          path: dist/web-ext
+          name: dist
+          path: dist
       - name: Prepare release packages
         run: |
           cp ./dist/web-ext/mozilla/pontoon_add-on-*.zip "./pontoon_add-on-${{ steps.git_info.outputs.SOURCE_TAG }}-mozilla.zip"
           cp ./dist/web-ext/chrome/pontoon_add-on-*.zip "./pontoon_add-on-${{ steps.git_info.outputs.SOURCE_TAG }}-chrome.zip"
+          cp ./dist/privacy-policy.html "./privacy-policy-${{ steps.git_info.outputs.SOURCE_TAG }}.html"
       - name: Upload Firefox version to GitHub
         uses: actions/upload-release-asset@v1
         env:
@@ -69,3 +70,12 @@ jobs:
           asset_path: ./pontoon_add-on-${{ steps.git_info.outputs.SOURCE_TAG }}-chrome.zip
           asset_name: pontoon_add-on-${{ steps.git_info.outputs.SOURCE_TAG }}-chrome.zip
           asset_content_type: application/zip
+      - name: Upload privacy policy HTML to GitHub
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./privacy-policy-${{ steps.git_info.outputs.SOURCE_TAG }}.html
+          asset_name: privacy-policy-${{ steps.git_info.outputs.SOURCE_TAG }}.html
+          asset_content_type: text/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Save built add-on
         uses: actions/upload-artifact@v2
         with:
-          name: dist_web-ext
-          path: dist/web-ext
+          name: dist
+          path: dist
           retention-days: 30
       - name: Upload code coverage to Codecov
         env:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "bootstrap": "lerna bootstrap --force-local",
-    "build": "run-s packages:clean clean packages:build build:mozilla build:chrome build:lint",
+    "build": "run-s packages:clean clean packages:build build:mozilla build:chrome build:lint build:privacy-policy-html",
     "watch": "run-s packages:clean packages:watch",
     "test": "run-s packages:test",
     "clean": "rimraf dist coverage tmp",
@@ -30,10 +30,12 @@
     "packages:clean": "lerna exec --parallel -- yarn clean",
     "build:mozilla": "echo 'Packaging for Mozilla based browsers.' && web-ext build --config ./web-ext.config.js -s ./src -a ./dist/web-ext/mozilla",
     "build:chrome": "echo 'Packaging for Chromium based browsers.' && bash ./scripts/build-chrome.sh",
-    "build:lint": "web-ext lint --config ./web-ext.config.js -s ./src"
+    "build:lint": "web-ext lint --config ./web-ext.config.js -s ./src",
+    "build:privacy-policy-html": "mkdir -p ./dist && marked -i PRIVACY.md -o ./dist/privacy-policy.html"
   },
   "devDependencies": {
     "lerna": "^3.22.1",
+    "marked": "^2.0.3",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "web-ext": "^5.4.1"


### PR DESCRIPTION
Using `marked`, convert privacy policy from PRIVACY.md to HTML snippet, which can be copied to AMO. Which means there will be a single source of the privacy policy text, and all the other format are directly generated from it by GitHub Actions.

This is the last piece listed in #146, so fix #146.