### PR TITLE
Remove custom serialization of PontoonAddonInfo for window.postMessage

### DIFF
--- a/src/packages/content-scripts/src/pontoon-addon-promotion/content-script.ts
+++ b/src/packages/content-scripts/src/pontoon-addon-promotion/content-script.ts
@@ -10,10 +10,10 @@ function injectScript(src: string) {
 
 async function postMessage(): Promise<void> {
   window.postMessage(
-    JSON.stringify({
+    {
       _type: 'PontoonAddonInfo',
       value: pontoonAddonInfo,
-    }),
+    },
     '*' // required to work for localhost:<port> (<port> may not be part of the baseUrl)
   );
 }


### PR DESCRIPTION
TODO:
- [x] needs support for both the new and old format in Pontoon frontend, probably can be done in https://bugzilla.mozilla.org/show_bug.cgi?id=1712086 (https://github.com/mozilla/pontoon/pull/1950)