### PR TITLE
Show project links in the toolbar button

### DIFF
--- a/src/background/__mocks__/backgroundClient.ts
+++ b/src/background/__mocks__/backgroundClient.ts
@@ -6,11 +6,7 @@ export const getNotificationsUrl = jest.fn();
 
 export const getSettingsUrl = jest.fn();
 
-export const getTeamPageUrl = jest.fn();
-
 export const getTeamProjectUrl = jest.fn();
-
-export const getStringsWithStatusSearchUrl = jest.fn();
 
 export const getSignInURL = jest.fn();
 

--- a/src/background/backgroundClient.spec.ts
+++ b/src/background/backgroundClient.spec.ts
@@ -9,9 +9,7 @@ import {
   getPontoonProjectForTheCurrentTab,
   getSettingsUrl,
   getSignInURL,
-  getStringsWithStatusSearchUrl,
   getUsersTeamFromPontoon,
-  getTeamPageUrl,
   getTeamProjectUrl,
   markAllNotificationsAsRead,
   notificationBellIconScriptLoaded,
@@ -74,24 +72,10 @@ describe('backgroundClient', () => {
     expect(url).toBe('https://localhost/settings/?utm_source=pontoon-addon');
   });
 
-  it('getTeamPageUrl', async () => {
-    const url = await getTeamPageUrl();
-
-    expect(url).toBe('https://localhost/cs?utm_source=pontoon-addon');
-  });
-
   it('getTeamProjectUrl', async () => {
     const url = await getTeamProjectUrl('/projects/firefox');
 
     expect(url).toBe('https://localhost/cs/firefox?utm_source=pontoon-addon');
-  });
-
-  it('getStringsWithStatusSearchUrl', async () => {
-    const url = await getStringsWithStatusSearchUrl('translated');
-
-    expect(url).toBe(
-      'https://localhost/cs/all-projects/all-resources?status=translated&utm_source=pontoon-addon',
-    );
   });
 
   it('getSignInURL', async () => {

--- a/src/background/backgroundClient.spec.ts
+++ b/src/background/backgroundClient.spec.ts
@@ -123,15 +123,11 @@ describe('backgroundClient', () => {
   it('getPontoonProjectForTheCurrentTab', async () => {
     mockBrowserSendMessage()
       .expect({ type: BackgroundClientMessageType.GET_CURRENT_TAB_PROJECT })
-      .andResolve({
-        name: 'firefox',
-        pageUrl: '/pageUrl',
-        translationUrl: '/translationsUrl',
-      });
+      .andResolve({ slug: 'firefox' });
 
     const project = await getPontoonProjectForTheCurrentTab();
 
-    expect(project!.name).toBe('firefox');
+    expect(project!.slug).toBe('firefox');
   });
 
   it('pageLoaded', async () => {

--- a/src/background/backgroundClient.ts
+++ b/src/background/backgroundClient.ts
@@ -11,12 +11,6 @@ import { getOneOption } from '@commons/options';
 
 import { BackgroundClientMessageType } from './BackgroundClientMessageType';
 
-export interface ProjectForCurrentTab {
-  name: string;
-  pageUrl: string;
-  translationUrl: string;
-}
-
 async function getTeam(): Promise<{ code: string }> {
   return {
     code: await getOneOption('locale_team'),
@@ -69,7 +63,7 @@ export async function getUsersTeamFromPontoon(): Promise<string | undefined> {
 }
 
 export async function getPontoonProjectForTheCurrentTab(): Promise<
-  ProjectForCurrentTab | undefined
+  StorageContent['projectsList'][string] | undefined
 > {
   return await browser.runtime.sendMessage({
     type: BackgroundClientMessageType.GET_CURRENT_TAB_PROJECT,

--- a/src/background/backgroundClient.ts
+++ b/src/background/backgroundClient.ts
@@ -1,9 +1,7 @@
 import {
   pontoonFxaSignIn,
   pontoonSettings,
-  pontoonTeam,
   pontoonNotifications,
-  pontoonSearchStringsWithStatus,
   toPontoonTeamSpecificProjectUrl,
 } from '@commons/webLinks';
 import { browser, StorageContent } from '@commons/webExtensionsApi';
@@ -29,21 +27,9 @@ export async function getSettingsUrl(): Promise<string> {
   return pontoonSettings(await getPontoonBaseUrl());
 }
 
-export async function getTeamPageUrl(): Promise<string> {
-  const [baseUrl, team] = await Promise.all([getPontoonBaseUrl(), getTeam()]);
-  return pontoonTeam(baseUrl, team);
-}
-
 export async function getTeamProjectUrl(projectUrl: string): Promise<string> {
   const [baseUrl, team] = await Promise.all([getPontoonBaseUrl(), getTeam()]);
   return toPontoonTeamSpecificProjectUrl(baseUrl, team, projectUrl);
-}
-
-export async function getStringsWithStatusSearchUrl(
-  status: string,
-): Promise<string> {
-  const [baseUrl, team] = await Promise.all([getPontoonBaseUrl(), getTeam()]);
-  return pontoonSearchStringsWithStatus(baseUrl, team, status);
 }
 
 export async function getSignInURL(): Promise<string> {

--- a/src/background/contextButtons.ts
+++ b/src/background/contextButtons.ts
@@ -1,4 +1,7 @@
-import { pontoonSearchInProject, newLocalizationBug } from '@commons/webLinks';
+import {
+  pontoonProjectTranslationView,
+  newLocalizationBug,
+} from '@commons/webLinks';
 import {
   listenToMessages,
   openNewTab,
@@ -19,7 +22,7 @@ function listenToMessagesFromContentScript() {
       const { pontoon_base_url: pontoonBaseUrl, locale_team: teamCode } =
         await getOptions(['pontoon_base_url', 'locale_team']);
       openNewTab(
-        pontoonSearchInProject(
+        pontoonProjectTranslationView(
           pontoonBaseUrl,
           { code: teamCode },
           { slug: 'all-projects' },

--- a/src/background/contextMenu.ts
+++ b/src/background/contextMenu.ts
@@ -1,6 +1,10 @@
 import type { Menus, Tabs } from 'webextension-polyfill';
 
-import { pontoonSearchInProject, newLocalizationBug } from '@commons/webLinks';
+import {
+  pontoonProjectTranslationView,
+  newLocalizationBug,
+  pontoonTeamsProject,
+} from '@commons/webLinks';
 import {
   openNewTab,
   getFromStorage,
@@ -11,6 +15,14 @@ import {
 } from '@commons/webExtensionsApi';
 import { getOptions, listenToOptionChange } from '@commons/options';
 import { OptionsContent } from '@commons/data/defaultOptions';
+
+const GENERIC_CONTEXTS: Menus.ContextType[] = [
+  'page',
+  'editable',
+  'image',
+  'video',
+];
+const SELECTED_TEXT_CONTEXTS: Menus.ContextType[] = ['selection'];
 
 export function setupPageContextMenus() {
   listenToStorageChange('projectsList', () => createContextMenuItems());
@@ -39,7 +51,7 @@ async function createContextMenuItems() {
       id: 'page-context-menu-parent',
       title: 'Pontoon Add-on',
       documentUrlPatterns: mozillaWebsitesUrlPatterns,
-      contexts: ['selection'],
+      contexts: [...GENERIC_CONTEXTS, ...SELECTED_TEXT_CONTEXTS],
     });
     const allProjectsMenuItems = Object.values(projects).flatMap((project) =>
       contextMenuItemsForProject(project, pontoonBaseUrl, team),
@@ -47,15 +59,31 @@ async function createContextMenuItems() {
     for (const item of allProjectsMenuItems) {
       await recreateContextMenu({
         ...item,
-        contexts: ['selection'],
         parentId: parentContextMenuId,
       });
     }
     await recreateContextMenu({
-      id: 'page-context-menu-report-l10n-bug',
+      id: `search-in-all-projects`,
+      title: `Search for "%s" in ${team.name} translations of all projects`,
+      documentUrlPatterns: mozillaWebsitesUrlPatterns,
+      contexts: SELECTED_TEXT_CONTEXTS,
+      parentId: parentContextMenuId,
+      onclick: (info: Menus.OnClickData) => {
+        openNewTab(
+          pontoonProjectTranslationView(
+            pontoonBaseUrl,
+            team,
+            { slug: 'all-projects' },
+            info.selectionText,
+          ),
+        );
+      },
+    });
+    await recreateContextMenu({
+      id: 'report-l10n-bug',
       title: 'Report l10n bug for "%s"',
       documentUrlPatterns: mozillaWebsitesUrlPatterns,
-      contexts: ['selection'],
+      contexts: SELECTED_TEXT_CONTEXTS,
       parentId: parentContextMenuId,
       onclick: (info: Menus.OnClickData, tab: Tabs.Tab) =>
         openNewTab(
@@ -72,45 +100,49 @@ async function createContextMenuItems() {
 function contextMenuItemsForProject(
   project: StorageContent['projectsList'][string],
   pontoonBaseUrl: OptionsContent['pontoon_base_url'],
-  team: { code: string },
+  team: StorageContent['teamsList'][string],
 ): Menus.CreateCreatePropertiesType[] {
-  return project.domains
-    .flatMap((domain) => ({ project, domain }))
-    .flatMap(({ project, domain }) => {
-      const domainSlug = domain.replace('.', '_');
-      return [
-        {
-          id: `page-context-menu-search-${project.slug}-${domainSlug}`,
-          title: `Search for "%s" in Pontoon (${project.name})`,
-          documentUrlPatterns: [`https://${domain}/*`],
-          onclick: async (info: Menus.OnClickData) => {
-            openNewTab(
-              pontoonSearchInProject(
-                pontoonBaseUrl,
-                team,
-                project,
-                info.selectionText,
-              ),
-            );
-          },
-        },
-        {
-          id: `page-context-menu-search-all-${domainSlug}`,
-          title: 'Search for "%s" in Pontoon (all projects)',
-          documentUrlPatterns: [`https://${domain}/*`],
-          onclick: async (info: Menus.OnClickData) => {
-            openNewTab(
-              pontoonSearchInProject(
-                pontoonBaseUrl,
-                team,
-                { slug: 'all-projects' },
-                info.selectionText,
-              ),
-            );
-          },
-        },
-      ];
-    });
+  const documentUrlPatterns = project.domains.map(
+    (domain) => `https://${domain}/*`,
+  );
+  return [
+    {
+      id: `open-project-dashboard-${project.slug}`,
+      title: `Open ${project.name} dashboard for ${team.name}`,
+      documentUrlPatterns,
+      contexts: [...GENERIC_CONTEXTS, ...SELECTED_TEXT_CONTEXTS],
+      onclick: () => {
+        openNewTab(pontoonTeamsProject(pontoonBaseUrl, team, project));
+      },
+    },
+    {
+      id: `open-translation-view-${project.slug}`,
+      title: `Open ${project.name} translation view for ${team.name}`,
+      documentUrlPatterns,
+      contexts: GENERIC_CONTEXTS,
+      onclick: () => {
+        openNewTab(
+          pontoonProjectTranslationView(pontoonBaseUrl, team, project),
+        );
+      },
+    },
+    {
+      id: `search-in-project-${project.slug}`,
+      title: `Search for "%s" in ${team.name} translations of ${project.name}`,
+      documentUrlPatterns,
+      contexts: SELECTED_TEXT_CONTEXTS,
+      onclick: (info: Menus.OnClickData) => {
+        openNewTab(
+          pontoonProjectTranslationView(
+            pontoonBaseUrl,
+            team,
+            project,
+            info.selectionText,
+          ),
+        );
+      },
+    },
+  ];
 }
 
 async function recreateContextMenu(

--- a/src/background/toolbarButton.ts
+++ b/src/background/toolbarButton.ts
@@ -20,7 +20,7 @@ import {
   pontoonTeam,
   pontoonTeamInsights,
   pontoonTeamBugs,
-  pontoonSearchInProject,
+  pontoonProjectTranslationView,
   transvisionHome,
   mozillaL10nStyleGuide,
   mozillaWikiL10nTeamPage,
@@ -191,7 +191,7 @@ async function addContextMenu() {
         const { pontoon_base_url: pontoonBaseUrl, locale_team: teamCode } =
           await getOptions(['pontoon_base_url', 'locale_team']);
         openNewTab(
-          pontoonSearchInProject(
+          pontoonProjectTranslationView(
             pontoonBaseUrl,
             { code: teamCode },
             { slug: 'all-projects' },
@@ -219,7 +219,7 @@ async function addContextMenu() {
         const { pontoon_base_url: pontoonBaseUrl, locale_team: teamCode } =
           await getOptions(['pontoon_base_url', 'locale_team']);
         openNewTab(
-          pontoonSearchInProject(
+          pontoonProjectTranslationView(
             pontoonBaseUrl,
             { code: teamCode },
             { slug: 'all-projects' },

--- a/src/commons/webLinks.spec.ts
+++ b/src/commons/webLinks.spec.ts
@@ -123,22 +123,19 @@ describe('webLinks', () => {
         'Mozilla Localizations',
       )}&component=${encodeURIComponent(
         'Czech L10N',
-      )}&status_whiteboard=${encodeURIComponent(
-        '[pontoon-addon-feedback]',
-      )}&bug_file_loc=${encodeURIComponent(
-        'https://localhost?foo=bar',
       )}&short_desc=${encodeURIComponent(
         '[cs] Translation update proposed for "report this" on https://localhost?foo=bar',
       )}&comment=${encodeURIComponent(
         'The translation:\nreport this\n\nShould be:\n',
-      )}`,
+      )}&status_whiteboard=${encodeURIComponent(
+        '[pontoon-addon-feedback]',
+      )}&bug_file_loc=${encodeURIComponent('https://localhost?foo=bar')}`,
     );
   });
 
-  it('newLocalizationBug without selected text', () => {
+  it('newLocalizationBug with minimal information', () => {
     const url = newLocalizationBug({
       team: { code: 'cs', bz_component: 'Czech L10N' },
-      url: 'https://localhost?foo=bar',
     });
 
     expect(url).toBe(
@@ -146,13 +143,9 @@ describe('webLinks', () => {
         'Mozilla Localizations',
       )}&component=${encodeURIComponent(
         'Czech L10N',
-      )}&status_whiteboard=${encodeURIComponent(
-        '[pontoon-addon-feedback]',
-      )}&bug_file_loc=${encodeURIComponent(
-        'https://localhost?foo=bar',
       )}&short_desc=${encodeURIComponent(
-        '[cs] Translation update proposed on https://localhost?foo=bar',
-      )}`,
+        '[cs] Translation update proposed',
+      )}&status_whiteboard=${encodeURIComponent('[pontoon-addon-feedback]')}`,
     );
   });
 });

--- a/src/commons/webLinks.spec.ts
+++ b/src/commons/webLinks.spec.ts
@@ -2,13 +2,14 @@ import {
   newLocalizationBug,
   pontoonFxaSignIn,
   pontoonNotifications,
-  pontoonSearchInProject,
+  pontoonProjectTranslationView,
   pontoonSearchStringsWithStatus,
   pontoonSettings,
   pontoonTeam,
   pontoonTeamBugs,
   pontoonTeamInsights,
   pontoonTeamsList,
+  pontoonTeamsProject,
   toPontoonTeamSpecificProjectUrl,
 } from './webLinks';
 
@@ -54,8 +55,18 @@ describe('webLinks', () => {
     expect(url).toBe('https://localhost/cs/bugs');
   });
 
-  it('pontoonSearchInProject', () => {
-    const url = pontoonSearchInProject(
+  it('pontoonTeamsProject', () => {
+    const url = pontoonTeamsProject(
+      'https://localhost',
+      { code: 'cs' },
+      { slug: 'firefox' },
+    );
+
+    expect(url).toBe('https://localhost/cs/firefox?utm_source=pontoon-addon');
+  });
+
+  it('pontoonProjectTranslationView', () => {
+    const url = pontoonProjectTranslationView(
       'https://localhost',
       { code: 'cs' },
       { slug: 'firefox' },

--- a/src/commons/webLinks.spec.ts
+++ b/src/commons/webLinks.spec.ts
@@ -134,4 +134,25 @@ describe('webLinks', () => {
       )}`,
     );
   });
+
+  it('newLocalizationBug without selected text', () => {
+    const url = newLocalizationBug({
+      team: { code: 'cs', bz_component: 'Czech L10N' },
+      url: 'https://localhost?foo=bar',
+    });
+
+    expect(url).toBe(
+      `https://bugzilla.mozilla.org/enter_bug.cgi?product=${encodeURIComponent(
+        'Mozilla Localizations',
+      )}&component=${encodeURIComponent(
+        'Czech L10N',
+      )}&status_whiteboard=${encodeURIComponent(
+        '[pontoon-addon-feedback]',
+      )}&bug_file_loc=${encodeURIComponent(
+        'https://localhost?foo=bar',
+      )}&short_desc=${encodeURIComponent(
+        '[cs] Translation update proposed on https://localhost?foo=bar',
+      )}`,
+    );
+  });
 });

--- a/src/commons/webLinks.ts
+++ b/src/commons/webLinks.ts
@@ -199,23 +199,28 @@ export function newLocalizationBug({
 }: {
   team: { code: string; bz_component: string };
   selectedText?: string;
-  url: string;
+  url?: string;
 }): string {
   return URITemplate('https://bugzilla.mozilla.org/enter_bug.cgi{?q*}')
     .expand({
       q: {
         product: 'Mozilla Localizations',
         component: team.bz_component,
-        status_whiteboard: '[pontoon-addon-feedback]',
-        bug_file_loc: url,
-        short_desc: selectedText
-          ? `[${
-              team.code
-            }] Translation update proposed for "${selectedText.trim()}" on ${url}`
-          : `[${team.code}] Translation update proposed on ${url}`,
+        short_desc:
+          selectedText && url
+            ? `[${
+                team.code
+              }] Translation update proposed for "${selectedText.trim()}" on ${url}`
+            : `[${team.code}] Translation update proposed`,
         ...(selectedText
           ? {
               comment: `The translation:\n${selectedText.trim()}\n\nShould be:\n`,
+            }
+          : {}),
+        status_whiteboard: '[pontoon-addon-feedback]',
+        ...(url
+          ? {
+              bug_file_loc: url,
             }
           : {}),
       },

--- a/src/commons/webLinks.ts
+++ b/src/commons/webLinks.ts
@@ -77,7 +77,23 @@ export function pontoonTeamBugs(
     .toString();
 }
 
-export function pontoonSearchInProject(
+export function pontoonTeamsProject(
+  baseUrl: string,
+  team: { code: string },
+  project: { slug: string },
+): string {
+  return URITemplate('{+baseUrl}{/path*}{?q*}')
+    .expand({
+      baseUrl,
+      path: [team.code, project.slug],
+      q: {
+        utm_source: LINK_UTM_SOURCE,
+      },
+    })
+    .toString();
+}
+
+export function pontoonProjectTranslationView(
   baseUrl: string,
   team: { code: string },
   project: { slug: string },

--- a/src/commons/webLinks.ts
+++ b/src/commons/webLinks.ts
@@ -198,7 +198,7 @@ export function newLocalizationBug({
   url,
 }: {
   team: { code: string; bz_component: string };
-  selectedText: string;
+  selectedText?: string;
   url: string;
 }): string {
   return URITemplate('https://bugzilla.mozilla.org/enter_bug.cgi{?q*}')
@@ -208,10 +208,16 @@ export function newLocalizationBug({
         component: team.bz_component,
         status_whiteboard: '[pontoon-addon-feedback]',
         bug_file_loc: url,
-        short_desc: `[${
-          team.code
-        }] Translation update proposed for "${selectedText.trim()}" on ${url}`,
-        comment: `The translation:\n${selectedText.trim()}\n\nShould be:\n`,
+        short_desc: selectedText
+          ? `[${
+              team.code
+            }] Translation update proposed for "${selectedText.trim()}" on ${url}`
+          : `[${team.code}] Translation update proposed on ${url}`,
+        ...(selectedText
+          ? {
+              comment: `The translation:\n${selectedText.trim()}\n\nShould be:\n`,
+            }
+          : {}),
       },
     })
     .toString();

--- a/src/content-scripts/context-buttons.ts
+++ b/src/content-scripts/context-buttons.ts
@@ -52,7 +52,7 @@ allContextButtons.forEach((button) => {
 document.addEventListener('mouseup', (e) => {
   const selectedText = getSelectedText();
   if (selectedText.length > 0) {
-    pontoonSearchButton.title = `Search for "${selectedText.trim()}" in Pontoon (all projects)`;
+    pontoonSearchButton.title = `Search for "${selectedText.trim()}" in translations of all projects`;
     bugzillaReportButton.title = `Report l10n bug for "${selectedText.trim()}"`;
 
     const yCoord = window.scrollY + e.screenY - 120;

--- a/src/frontend/address-bar/App/index.tsx
+++ b/src/frontend/address-bar/App/index.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 
 import type { OptionsContent } from '@commons/data/defaultOptions';
 import {
+  getActiveTab,
   getOneFromStorage,
   openNewTab,
   StorageContent,
 } from '@commons/webExtensionsApi';
 import { getOptions } from '@commons/options';
 import {
+  newLocalizationBug,
   pontoonProjectTranslationView,
   pontoonTeamsProject,
 } from '@commons/webLinks';
@@ -56,6 +58,16 @@ export const App: React.FC = () => {
           onClick: () =>
             openNewTab(
               pontoonProjectTranslationView(pontoonBaseUrl, team, project),
+            ),
+        },
+        {
+          text: `Report bug for localization of ${project.name} to ${team.name}`,
+          onClick: async () =>
+            openNewTab(
+              newLocalizationBug({
+                team,
+                url: (await getActiveTab()).url!,
+              }),
             ),
         },
       ]}

--- a/src/frontend/address-bar/App/index.tsx
+++ b/src/frontend/address-bar/App/index.tsx
@@ -1,32 +1,62 @@
 import React, { useEffect, useState } from 'react';
 
-import { openNewTab } from '@commons/webExtensionsApi';
+import type { OptionsContent } from '@commons/data/defaultOptions';
 import {
-  getPontoonProjectForTheCurrentTab,
-  ProjectForCurrentTab,
-} from '@background/backgroundClient';
+  getOneFromStorage,
+  openNewTab,
+  StorageContent,
+} from '@commons/webExtensionsApi';
+import { getOptions } from '@commons/options';
+import {
+  pontoonProjectTranslationView,
+  pontoonTeamsProject,
+} from '@commons/webLinks';
+import { getPontoonProjectForTheCurrentTab } from '@background/backgroundClient';
 
 import { PanelSection } from '../PanelSection';
 
 export const App: React.FC = () => {
-  const [project, setProject] = useState<ProjectForCurrentTab | undefined>();
+  const [project, setProject] = useState<
+    StorageContent['projectsList'][string] | undefined
+  >();
+  const [team, setTeam] = useState<
+    StorageContent['teamsList'][string] | undefined
+  >();
+  const [pontoonBaseUrl, setPontoonBaseUrl] = useState<
+    OptionsContent['pontoon_base_url'] | undefined
+  >();
 
   useEffect(() => {
     (async () => {
-      setProject(await getPontoonProjectForTheCurrentTab());
+      const [
+        projectForCurrentTab,
+        teamsList,
+        { locale_team: teamCode, pontoon_base_url },
+      ] = await Promise.all([
+        getPontoonProjectForTheCurrentTab(),
+        getOneFromStorage('teamsList'),
+        getOptions(['locale_team', 'pontoon_base_url']),
+      ]);
+      setProject(projectForCurrentTab);
+      setTeam(teamsList![teamCode]);
+      setPontoonBaseUrl(pontoon_base_url);
     })();
   }, []);
 
-  return project ? (
+  return project && team && pontoonBaseUrl ? (
     <PanelSection
       items={[
         {
-          text: `Open ${project.name} project page`,
-          onClick: () => openNewTab(project.pageUrl),
+          text: `Open ${project.name} dashboard for ${team.name}`,
+          onClick: () =>
+            openNewTab(pontoonTeamsProject(pontoonBaseUrl, team, project)),
         },
         {
-          text: `Open ${project.name} translation view`,
-          onClick: () => openNewTab(project.translationUrl),
+          text: `Open ${project.name} translation view for ${team.name}`,
+          onClick: () =>
+            openNewTab(
+              pontoonProjectTranslationView(pontoonBaseUrl, team, project),
+            ),
         },
       ]}
     />

--- a/src/frontend/index.spec.ts
+++ b/src/frontend/index.spec.ts
@@ -3,12 +3,9 @@ import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import flushPromises from 'flush-promises';
 
-import { getFromStorage } from '@commons/webExtensionsApi';
+import { getFromStorage, getOneFromStorage } from '@commons/webExtensionsApi';
 import { getOptions } from '@commons/options';
-import {
-  getPontoonProjectForTheCurrentTab,
-  ProjectForCurrentTab,
-} from '@background/backgroundClient';
+import { getPontoonProjectForTheCurrentTab } from '@background/backgroundClient';
 
 import { render } from './index';
 
@@ -20,6 +17,7 @@ const reactDomRender = jest.spyOn(ReactDOM, 'render') as jest.Mock;
 
 afterEach(() => {
   reactDomRender.mockReset();
+  jest.resetAllMocks();
   document.body.textContent = '';
 });
 
@@ -41,13 +39,15 @@ describe('address bar', () => {
   beforeEach(() => {
     (getPontoonProjectForTheCurrentTab as jest.Mock).mockReturnValue({
       name: 'Some project',
-      pageUrl: 'https://127.0.0.1/',
-      translationUrl: 'https://127.0.0.1/',
-    } as ProjectForCurrentTab);
-  });
-
-  afterEach(() => {
-    (getPontoonProjectForTheCurrentTab as jest.Mock).mockReset();
+      slug: 'some-project',
+    });
+    (getOneFromStorage as jest.Mock).mockResolvedValue({
+      cs: { name: 'Czech' },
+    });
+    (getOptions as jest.Mock).mockResolvedValue({
+      locale_team: 'cs',
+      pontoon_base_url: 'https://localhost',
+    });
   });
 
   it('renders', async () => {
@@ -91,11 +91,6 @@ describe('toolbar button', () => {
       teamsList: { cs: {} },
       latestTeamsActivity: { cs: {} },
     }));
-  });
-
-  afterEach(() => {
-    (getOptions as jest.Mock).mockReset();
-    (getFromStorage as jest.Mock).mockReset();
   });
 
   it('renders', async () => {

--- a/src/frontend/index.spec.ts
+++ b/src/frontend/index.spec.ts
@@ -3,7 +3,11 @@ import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import flushPromises from 'flush-promises';
 
-import { getFromStorage, getOneFromStorage } from '@commons/webExtensionsApi';
+import {
+  getActiveTab,
+  getFromStorage,
+  getOneFromStorage,
+} from '@commons/webExtensionsApi';
 import { getOptions } from '@commons/options';
 import { getPontoonProjectForTheCurrentTab } from '@background/backgroundClient';
 
@@ -42,11 +46,14 @@ describe('address bar', () => {
       slug: 'some-project',
     });
     (getOneFromStorage as jest.Mock).mockResolvedValue({
-      cs: { name: 'Czech' },
+      cs: { name: 'Czech', bz_component: 'L10N/CS' },
     });
     (getOptions as jest.Mock).mockResolvedValue({
       locale_team: 'cs',
       pontoon_base_url: 'https://localhost',
+    });
+    (getActiveTab as jest.Mock).mockResolvedValue({
+      url: 'https://localhost/firefox',
     });
   });
 

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en.json';
 
-import { getFromStorage } from '@commons/webExtensionsApi';
+import { getOneFromStorage } from '@commons/webExtensionsApi';
 import { getOptions } from '@commons/options';
 
 import { App as AddressBarApp } from './address-bar/App';
@@ -20,20 +20,16 @@ async function renderToolbarButtonApp(rootElement: HTMLElement): Promise<void> {
     {
       toolbar_button_popup_always_hide_read_notifications:
         hideReadNotifications,
-      locale_team: teamCode,
       pontoon_base_url: pontoonBaseUrl,
     },
-    { notificationsData, teamsList, latestTeamsActivity },
+    notificationsData,
   ] = await Promise.all([
     getOptions([
       'toolbar_button_popup_always_hide_read_notifications',
-      'locale_team',
       'pontoon_base_url',
     ]),
-    getFromStorage(['notificationsData', 'teamsList', 'latestTeamsActivity']),
+    getOneFromStorage('notificationsData'),
   ]);
-  const teamData = teamsList![teamCode];
-  const latestTeamActivity = latestTeamsActivity![teamCode];
 
   const baseTag = document.createElement('base');
   baseTag.href = pontoonBaseUrl;
@@ -43,8 +39,6 @@ async function renderToolbarButtonApp(rootElement: HTMLElement): Promise<void> {
     <ToolbarButtonApp
       notificationsData={notificationsData}
       hideReadNotifications={hideReadNotifications}
-      teamData={teamData}
-      latestTeamActivity={latestTeamActivity}
     />,
     rootElement,
   );

--- a/src/frontend/toolbar-button/App/index.tsx
+++ b/src/frontend/toolbar-button/App/index.tsx
@@ -21,23 +21,12 @@ const GlobalStyle = createGlobalStyle`
 interface Props {
   notificationsData: any;
   hideReadNotifications?: boolean;
-  teamData?: {
-    name?: string;
-    code?: string;
-    strings?: any;
-  };
-  latestTeamActivity?: {
-    user: string;
-    date_iso?: string;
-  };
 }
 
 export const App: React.FC<Props> = ({
   notificationsData,
   hideReadNotifications,
-  teamData,
-  latestTeamActivity,
-}) => {
+}: Props) => {
   return (
     <>
       <GlobalPontoonStyle />
@@ -46,12 +35,7 @@ export const App: React.FC<Props> = ({
         notificationsData={notificationsData}
         hideReadNotifications={hideReadNotifications}
       />
-      <TeamInfo
-        name={teamData?.name}
-        code={teamData?.code}
-        stringsData={teamData?.strings}
-        latestActivity={latestTeamActivity}
-      />
+      <TeamInfo />
     </>
   );
 };

--- a/src/frontend/toolbar-button/BottomLink/index.tsx
+++ b/src/frontend/toolbar-button/BottomLink/index.tsx
@@ -20,10 +20,9 @@ const Link = styled.button`
 `;
 
 interface Props {
-  text: string;
   onClick: () => void;
 }
 
-export const BottomLink: React.FC<Props> = ({ text, onClick }) => {
-  return <Link onClick={onClick}>{text}</Link>;
+export const BottomLink: React.FC<Props> = ({ onClick, children }) => {
+  return <Link onClick={onClick}>{children}</Link>;
 };

--- a/src/frontend/toolbar-button/BottomLink/index.tsx
+++ b/src/frontend/toolbar-button/BottomLink/index.tsx
@@ -7,7 +7,6 @@ const Link = styled.button`
   width: 100%;
   background: transparent;
   border: none;
-  border-top: 1px solid #525a65;
   padding: 0.5em;
   text-align: center;
   font-size: 14px;

--- a/src/frontend/toolbar-button/BottomLink/spec.tsx
+++ b/src/frontend/toolbar-button/BottomLink/spec.tsx
@@ -6,14 +6,14 @@ import { BottomLink } from '.';
 
 describe('BottomLink', () => {
   it('renders text', () => {
-    const wrapper = mount(<BottomLink text="TEXT" onClick={jest.fn()} />);
+    const wrapper = mount(<BottomLink onClick={jest.fn()}>TEXT</BottomLink>);
 
     expect(wrapper.find(BottomLink).text()).toBe('TEXT');
   });
 
   it('calls onClick handler', () => {
     const onClick = jest.fn();
-    const wrapper = mount(<BottomLink text="" onClick={onClick} />);
+    const wrapper = mount(<BottomLink onClick={onClick} />);
 
     act(() => {
       wrapper.find(BottomLink).simulate('click');

--- a/src/frontend/toolbar-button/NotificationsList/index.tsx
+++ b/src/frontend/toolbar-button/NotificationsList/index.tsx
@@ -18,6 +18,7 @@ const List = styled.ul`
   overflow: auto;
   margin: 0;
   padding: 0;
+  border-bottom: 1px solid #525a65;
 `;
 
 interface Props {

--- a/src/frontend/toolbar-button/NotificationsList/index.tsx
+++ b/src/frontend/toolbar-button/NotificationsList/index.tsx
@@ -14,7 +14,7 @@ import { NotificationsListError } from '../NotificationsListError';
 const List = styled.ul`
   list-style: none;
   text-align: center;
-  max-height: 280px;
+  max-height: 250px;
   overflow: auto;
   margin: 0;
   padding: 0;
@@ -63,18 +63,18 @@ export const NotificationsList: React.FC<Props> = ({
             ))}
         </List>
         {containsUnreadNotifications ? (
-          <BottomLink
-            text="Mark all Notifications as read"
-            onClick={() => markAllNotificationsAsRead()}
-          />
+          <BottomLink onClick={() => markAllNotificationsAsRead()}>
+            Mark all Notifications as read
+          </BottomLink>
         ) : (
           <BottomLink
-            text="See all Notifications"
             onClick={async () => {
               await openNewTab(await getNotificationsUrl());
               window.close();
             }}
-          />
+          >
+            See all Notifications
+          </BottomLink>
         )}
       </section>
     );

--- a/src/frontend/toolbar-button/TeamInfo/index.tsx
+++ b/src/frontend/toolbar-button/TeamInfo/index.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { CSSProperties, useState, useEffect } from 'react';
 import ReactTimeAgo from 'react-time-ago';
 import styled from 'styled-components';
 
 import {
+  getActiveTab,
+  getFromStorage,
+  openNewTab,
+  StorageContent,
+} from '@commons/webExtensionsApi';
+import { getOneOption } from '@commons/options';
+import { newLocalizationBug } from '@commons/webLinks';
+import {
   getTeamPageUrl,
   getStringsWithStatusSearchUrl,
+  getPontoonProjectForTheCurrentTab,
 } from '@background/backgroundClient';
-import { openNewTab } from '@commons/webExtensionsApi';
 import lightbulbImage from '@assets/img/lightbulb-blue.svg';
 
 import { BottomLink } from '../BottomLink';
@@ -34,6 +42,7 @@ const List = styled.ul`
   list-style-type: none;
   padding: 0.5em 1em 0.5em 0.5em;
   color: #aaa;
+  border-bottom: 1px solid #525a65;
 `;
 
 export const Name = styled.span`
@@ -46,52 +55,107 @@ export const Code = styled.span`
   color: #7bc876;
 `;
 
-interface Props {
-  name?: string;
-  code?: string;
-  stringsData?: any;
-  latestActivity?: {
-    user: string;
-    date_iso?: string;
-  };
-}
+const STRING_CATEGORIES: Array<{
+  status: string;
+  label: string;
+  dataProperty: keyof StorageContent['teamsList'][string]['strings'];
+  labelBeforeStyle?: CSSProperties;
+}> = [
+  {
+    status: 'translated',
+    label: 'translated',
+    dataProperty: 'approvedStrings',
+    labelBeforeStyle: { backgroundColor: '#7bc876' },
+  },
+  {
+    status: 'pretranslated',
+    label: 'pretranslated',
+    dataProperty: 'pretranslatedStrings',
+    labelBeforeStyle: { backgroundColor: '#c0ff00' },
+  },
+  {
+    status: 'warnings',
+    label: 'warnings',
+    dataProperty: 'stringsWithWarnings',
+    labelBeforeStyle: { backgroundColor: '#ffa10f' },
+  },
+  {
+    status: 'errors',
+    label: 'errors',
+    dataProperty: 'stringsWithErrors',
+    labelBeforeStyle: { backgroundColor: '#f36' },
+  },
+  {
+    status: 'missing',
+    label: 'missing',
+    dataProperty: 'missingStrings',
+    labelBeforeStyle: { backgroundColor: '#4d5967' },
+  },
+  {
+    status: 'unreviewed',
+    label: 'unreviewed',
+    dataProperty: 'unreviewedStrings',
+    labelBeforeStyle: {
+      height: '1em',
+      background: `center / contain no-repeat url(${lightbulbImage})`,
+    },
+  },
+  { status: 'all', label: 'all strings', dataProperty: 'totalStrings' },
+];
 
-async function openTeamPage(): Promise<void> {
-  const teamPageUrl = await getTeamPageUrl();
-  await openNewTab(teamPageUrl);
+async function openNewTabAndClosePopup(url: string): Promise<void> {
+  await openNewTab(url);
   window.close();
 }
 
-async function openTeamStringsWithStatus(status: string): Promise<void> {
-  const searchUrl = await getStringsWithStatusSearchUrl(status);
-  await openNewTab(searchUrl);
-  window.close();
-}
+export const TeamInfo: React.FC = () => {
+  const [projectForCurrentTab, setProjectForCurrentTab] = useState<
+    StorageContent['projectsList'][string] | undefined
+  >();
+  const [team, setTeam] = useState<
+    StorageContent['teamsList'][string] | undefined
+  >();
+  const [teamActivity, setTeamActivity] = useState<
+    StorageContent['latestTeamsActivity'][string] | undefined
+  >();
 
-export const TeamInfo: React.FC<Props> = ({
-  name = '',
-  code = '',
-  stringsData,
-  latestActivity,
-}) => {
-  return (
+  useEffect(() => {
+    (async () => {
+      const [
+        projectForCurrentTab,
+        { teamsList, latestTeamsActivity },
+        teamCode,
+      ] = await Promise.all([
+        getPontoonProjectForTheCurrentTab(),
+        getFromStorage(['teamsList', 'latestTeamsActivity']),
+        getOneOption('locale_team'),
+      ]);
+      setProjectForCurrentTab(projectForCurrentTab);
+      setTeam(teamsList![teamCode]);
+      setTeamActivity(latestTeamsActivity![teamCode]);
+    })();
+  }, []);
+
+  return team ? (
     <section>
       <Title>
-        <TitleLink onClick={() => openTeamPage()}>
-          <Name>{name}</Name> <Code>{code}</Code>
+        <TitleLink
+          onClick={async () => openNewTabAndClosePopup(await getTeamPageUrl())}
+        >
+          <Name>{team.name}</Name> <Code>{team.code}</Code>
         </TitleLink>
       </Title>
       <List>
-        {latestActivity && (
+        {teamActivity && (
           <TeamInfoListItem
             key="activity"
             label="Activity"
             value={
-              latestActivity.date_iso &&
-              !isNaN(Date.parse(latestActivity.date_iso)) ? (
+              teamActivity.date_iso &&
+              !isNaN(Date.parse(teamActivity.date_iso)) ? (
                 <>
-                  {latestActivity.user}{' '}
-                  <ReactTimeAgo date={new Date(latestActivity.date_iso)} />
+                  {teamActivity.user}{' '}
+                  <ReactTimeAgo date={new Date(teamActivity.date_iso)} />
                 </>
               ) : (
                 '―'
@@ -99,58 +163,41 @@ export const TeamInfo: React.FC<Props> = ({
             }
           />
         )}
-        {[
-          {
-            status: 'translated',
-            text: 'translated',
-            dataProperty: 'approvedStrings',
-            labelBeforeStyle: { backgroundColor: '#7bc876' },
-          },
-          {
-            status: 'pretranslated',
-            text: 'pretranslated',
-            dataProperty: 'pretranslatedStrings',
-            labelBeforeStyle: { backgroundColor: '#c0ff00' },
-          },
-          {
-            status: 'warnings',
-            text: 'warnings',
-            dataProperty: 'stringsWithWarnings',
-            labelBeforeStyle: { backgroundColor: '#ffa10f' },
-          },
-          {
-            status: 'errors',
-            text: 'errors',
-            dataProperty: 'stringsWithErrors',
-            labelBeforeStyle: { backgroundColor: '#f36' },
-          },
-          {
-            status: 'missing',
-            text: 'missing',
-            dataProperty: 'missingStrings',
-            labelBeforeStyle: { backgroundColor: '#4d5967' },
-          },
-          {
-            status: 'unreviewed',
-            text: 'unreviewed',
-            dataProperty: 'unreviewedStrings',
-            labelBeforeStyle: {
-              height: '1em',
-              background: `center / contain no-repeat url(${lightbulbImage})`,
-            },
-          },
-          { status: 'all', text: 'all strings', dataProperty: 'totalStrings' },
-        ].map((category) => (
+        {STRING_CATEGORIES.map((category) => (
           <TeamInfoListItem
             key={category.status}
             squareStyle={category.labelBeforeStyle}
-            label={category.text}
-            value={stringsData ? stringsData[category.dataProperty] : ''}
-            onClick={() => openTeamStringsWithStatus(category.status)}
+            label={category.label}
+            value={team.strings[category.dataProperty]}
+            onClick={async () =>
+              openNewTabAndClosePopup(
+                await getStringsWithStatusSearchUrl(category.status),
+              )
+            }
           />
         ))}
       </List>
-      <BottomLink text="Open team page" onClick={() => openTeamPage()} />
+      <BottomLink
+        text="Open team page"
+        onClick={async () => openNewTabAndClosePopup(await getTeamPageUrl())}
+      />
+      {projectForCurrentTab ? (
+        <BottomLink
+          text={`Report bug for localization of ${projectForCurrentTab.name} to ${team.name}`}
+          onClick={async () =>
+            openNewTabAndClosePopup(
+              newLocalizationBug({ team, url: (await getActiveTab()).url! }),
+            )
+          }
+        />
+      ) : (
+        <BottomLink
+          text={`Report bug for ${team.name} localization`}
+          onClick={() => openNewTabAndClosePopup(newLocalizationBug({ team }))}
+        />
+      )}
     </section>
+  ) : (
+    <></>
   );
 };

--- a/src/frontend/toolbar-button/TeamInfo/spec.tsx
+++ b/src/frontend/toolbar-button/TeamInfo/spec.tsx
@@ -5,16 +5,20 @@ import flushPromises from 'flush-promises';
 import ReactTimeAgo from 'react-time-ago';
 
 import {
+  getActiveTab,
   getFromStorage,
   openNewTab,
   StorageContent,
 } from '@commons/webExtensionsApi';
-import { getOneOption } from '@commons/options';
+import { getOptions } from '@commons/options';
 import {
-  getPontoonProjectForTheCurrentTab,
-  getStringsWithStatusSearchUrl,
-  getTeamPageUrl,
-} from '@background/backgroundClient';
+  newLocalizationBug,
+  pontoonProjectTranslationView,
+  pontoonSearchStringsWithStatus,
+  pontoonTeam,
+  pontoonTeamsProject,
+} from '@commons/webLinks';
+import { getPontoonProjectForTheCurrentTab } from '@background/backgroundClient';
 
 import { BottomLink } from '../BottomLink';
 import { TeamInfoListItem } from '../TeamInfoListItem';
@@ -53,11 +57,10 @@ beforeEach(() => {
       },
     },
   });
-  (getOneOption as jest.Mock).mockResolvedValue('cs');
-  (getTeamPageUrl as jest.Mock).mockReturnValue('https://127.0.0.1/team-page');
-  (getStringsWithStatusSearchUrl as jest.Mock).mockImplementation(
-    (status: string) => `https://127.0.0.1/${status}/`,
-  );
+  (getOptions as jest.Mock).mockResolvedValue({
+    locale_team: 'cs',
+    pontoon_base_url: 'https://localhost',
+  });
 });
 
 afterEach(() => {
@@ -124,13 +127,22 @@ describe('TeamInfo', () => {
     });
 
     wrapper.find(Name).simulate('click');
-    wrapper.find(Code).simulate('click');
-    wrapper.find(BottomLink).at(0).simulate('click');
-
     await flushPromises();
+    expect(openNewTab).toHaveBeenLastCalledWith(
+      pontoonTeam('https://localhost', team),
+    );
 
-    expect(openNewTab).toHaveBeenCalledWith('https://127.0.0.1/team-page');
-    expect(openNewTab).toHaveBeenCalledTimes(3);
+    wrapper.find(Code).simulate('click');
+    await flushPromises();
+    expect(openNewTab).toHaveBeenLastCalledWith(
+      pontoonTeam('https://localhost', team),
+    );
+
+    wrapper.find(BottomLink).at(0).simulate('click');
+    await flushPromises();
+    expect(openNewTab).toHaveBeenLastCalledWith(
+      pontoonTeam('https://localhost', team),
+    );
   });
 
   it('string status links work', async () => {
@@ -140,7 +152,10 @@ describe('TeamInfo', () => {
       wrapper.update();
     });
 
-    [
+    const statusLinks = wrapper.find(TeamInfoListItem);
+
+    const statuses = [
+      // Activity
       'translated',
       'pretranslated',
       'warnings',
@@ -148,15 +163,57 @@ describe('TeamInfo', () => {
       'missing',
       'unreviewed',
       'all',
-    ].forEach(async (status, index) => {
-      wrapper
-        .find(TeamInfoListItem)
-        .at(index + 1)
-        .simulate('click');
+    ];
+    expect(statusLinks).toHaveLength(statuses.length + 1);
+
+    for (const [index, status] of statuses.entries()) {
+      statusLinks.at(index + 1).find('button').simulate('click');
       await flushPromises();
-      expect(openNewTab).toHaveBeenCalledWith(`https://127.0.0.1/${status}/`);
-      expect(openNewTab).toHaveBeenCalledTimes(1);
-      (openNewTab as jest.Mock).mockReset();
+      expect(openNewTab).toHaveBeenLastCalledWith(
+        pontoonSearchStringsWithStatus('https://localhost', team, status),
+      );
+    }
+  });
+
+  it('renders links for project in the current tab', async () => {
+    const project = { name: 'Firefox', slug: 'firefox' };
+    (getPontoonProjectForTheCurrentTab as jest.Mock).mockResolvedValue(project);
+    (getActiveTab as jest.Mock).mockResolvedValue({
+      url: 'https://firefox.com',
     });
+
+    const wrapper = mount(<TeamInfo />);
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    const openDashboadLink = wrapper.find(BottomLink).at(1);
+    expect(openDashboadLink.text()).toBe('Open Firefox dashboard for Czech');
+    openDashboadLink.simulate('click');
+    await flushPromises();
+    expect(openNewTab).toHaveBeenLastCalledWith(
+      pontoonTeamsProject('https://localhost', team, project),
+    );
+
+    const translationViewLink = wrapper.find(BottomLink).at(2);
+    expect(translationViewLink.text()).toBe(
+      'Open Firefox translation view for Czech',
+    );
+    translationViewLink.simulate('click');
+    await flushPromises();
+    expect(openNewTab).toHaveBeenLastCalledWith(
+      pontoonProjectTranslationView('https://localhost', team, project),
+    );
+
+    const reportBugLink = wrapper.find(BottomLink).at(3);
+    expect(reportBugLink.text()).toBe(
+      'Report bug for localization of Firefox to Czech',
+    );
+    reportBugLink.simulate('click');
+    await flushPromises();
+    expect(openNewTab).toHaveBeenLastCalledWith(
+      newLocalizationBug({ team, url: 'https://firefox.com' }),
+    );
   });
 });

--- a/src/frontend/toolbar-button/TeamInfo/spec.tsx
+++ b/src/frontend/toolbar-button/TeamInfo/spec.tsx
@@ -167,7 +167,10 @@ describe('TeamInfo', () => {
     expect(statusLinks).toHaveLength(statuses.length + 1);
 
     for (const [index, status] of statuses.entries()) {
-      statusLinks.at(index + 1).find('button').simulate('click');
+      statusLinks
+        .at(index + 1)
+        .find('button')
+        .simulate('click');
       await flushPromises();
       expect(openNewTab).toHaveBeenLastCalledWith(
         pontoonSearchStringsWithStatus('https://localhost', team, status),


### PR DESCRIPTION
fix #137 

- [x] add _Open <project> project page_ and _Open <name> translation view_ links to context menus (non-selection)
- [x] add _Report l10n bug for <project>_ link to context menus (non-selection) and page action (as if the selected text was empty)
- [x] and _Report l10n bug for <team>_ link to toolbar button pop-up under _Open team page_ in the team info component
- [x] add _Open <project> project page_ and _Open <name> translation view_ links to toolbar button popup ~at the very bottom~ between team and Bugzilla links, based on the currently active tab