### PR TITLE
ci: replace set-output command by environment file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: Mark all required status checks were successful
         id: marker
-        run: echo "::set-output name=success::true"
+        run: echo "success=true" >> $GITHUB_OUTPUT
     outputs:
       success: ${{ steps.marker.outputs.success }}
   required_pre_merge_status_checks:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           tags: true
       - name: Output - release tag
         id: output_release_tag
-        run: echo "::set-output name=release_tag::$(git describe --tags --exact-match --abbrev=0)"
+        run: echo "release_tag=$(git describe --tags --exact-match --abbrev=0)" >> $GITHUB_OUTPUT
     outputs:
       release_tag: ${{ steps.output_release_tag.outputs.release_tag }}
   build:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/