### PR TITLE
fix: await opening a new tab before closing the popup

### DIFF
--- a/src/frontend/toolbar-button/NotificationsListItem/index.tsx
+++ b/src/frontend/toolbar-button/NotificationsListItem/index.tsx
@@ -138,7 +138,7 @@ function wrapLinks(pontoonBaseUrl: string): HTMLReactParserOptions['replace'] {
 
 async function openTeamProject(projectUrl: string): Promise<void> {
   const teamProjectUrl = await getTeamProjectUrl(projectUrl);
-  openNewPontoonTab(teamProjectUrl);
+  await openNewPontoonTab(teamProjectUrl);
   window.close();
 }
 


### PR DESCRIPTION
fix #635 