### PR TITLE
feat: indicate notifications are being loaded

### DIFF
--- a/src/background/RemotePontoon.ts
+++ b/src/background/RemotePontoon.ts
@@ -87,7 +87,12 @@ export function listenToMessagesFromClients() {
   );
 }
 
-export async function refreshData() {
+export async function refreshData(context: {
+  event: 'user interaction' | 'automation';
+}) {
+  if (context.event === 'user interaction') {
+    await saveToStorage({ notificationsDataLoadingState: 'loading' });
+  }
   await Promise.all([
     updateNotificationsData(),
     updateLatestTeamActivity(),
@@ -126,8 +131,12 @@ async function updateNotificationsData() {
     for (const notification of userData.notifications.notifications) {
       notificationsData[notification.id] = notification;
     }
-    await saveToStorage({ notificationsData });
+    await saveToStorage({
+      notificationsData,
+      notificationsDataLoadingState: 'loaded',
+    });
   } catch (error) {
+    await saveToStorage({ notificationsDataLoadingState: 'error' });
     await deleteFromStorage('notificationsData');
     console.error(error);
   }

--- a/src/background/dataRefresh.ts
+++ b/src/background/dataRefresh.ts
@@ -28,19 +28,23 @@ export function setupDataRefresh() {
     refreshDataWithInterval(periodInMinutes),
   );
   callDelayed({ delayInSeconds: 1 }, async () => {
-    await refreshData();
+    await refreshData({ event: 'user interaction' });
     console.info('Data refreshed after initialization.');
   });
 
-  listenToOptionChange('contextual_identity', () => refreshData());
-  listenToOptionChange('pontoon_base_url', () => refreshData());
+  listenToOptionChange('contextual_identity', () =>
+    refreshData({ event: 'user interaction' }),
+  );
+  listenToOptionChange('pontoon_base_url', () =>
+    refreshData({ event: 'user interaction' }),
+  );
 
   registerLiveDataProvider();
 }
 
 function refreshDataWithInterval(periodInMinutes: number) {
   callWithInterval('data-refresher-alarm', { periodInMinutes }, () =>
-    refreshData(),
+    refreshData({ event: 'automation' }),
   );
 }
 

--- a/src/commons/webExtensionsApi/index.ts
+++ b/src/commons/webExtensionsApi/index.ts
@@ -41,6 +41,7 @@ export interface StorageContent {
       bz_component: string;
     };
   };
+  notificationsDataLoadingState: 'loading' | 'loaded' | 'error' | undefined;
   notificationsData: {
     [id: number]: {
       id: number;


### PR DESCRIPTION
When notifications are loaded by user action (e.g. right after installation, when settings are updated, or the reload is triggered from the toolbar button context menu), the toolbar button badge icon briefly shows up to indicate the status. This badge does not show up when notifications are loaded during regular data refresh.

fix #734, #761