### PR TITLE
ci: automated upload to add-on stores

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           git config --local user.email '${{ github.actor }}@users.noreply.github.com'
           git config --local user.name '${{ github.actor }}'
       - name: Bump version
-        run: make bump_${{ inputs.version_component_to_bump }}_version_in_container # also creates the commit and tag
+        run: make bump_version_in_container bump='${{ inputs.version_component_to_bump }}' # also creates the commit and tag
       - name: Push release commit
         uses: ad-m/github-push-action@v0.8.0
         with:
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       checkout_ref: ${{ format('refs/tags/{0}', needs.bump_version_and_tag.outputs.release_tag) }}
-  create_release:
+  create_github_release:
     needs:
       - bump_version_and_tag
       - build
@@ -94,3 +94,52 @@ jobs:
           fail_on_unmatched_files: true
           draft: false
           prerelease: false
+  publish_to_amo:
+    needs:
+      - bump_version_and_tag
+      - build
+      - create_github_release
+    runs-on: ubuntu-latest
+    environment: addons.mozilla.org
+    timeout-minutes: 10
+    steps:
+      - name: Download built add-on to publish
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.production_artifact_name }}
+          path: dist
+      - name: Download source code archive
+        run: wget 'https://github.com/MikkCZ/pontoon-addon/archive/refs/tags/${{ needs.bump_version_and_tag.outputs.release_tag }}.zip'
+      - name: Publish to addons.mozilla.org
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
+          WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}
+        run: |
+          npx web-ext@8 sign \
+            --channel=listed \
+            --source-dir=./dist/mozilla/src \
+            --upload-source-code=./${{ needs.bump_version_and_tag.outputs.release_tag }}.zip \
+            --amo-metadata=./dist/mozilla/amo-metadata.json
+  publish_to_chrome_web_store:
+    needs:
+      - bump_version_and_tag
+      - build
+      - create_github_release
+    runs-on: ubuntu-latest
+    environment: Chrome Web Store
+    timeout-minutes: 10
+    steps:
+      - name: Download built add-on to publish
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.production_artifact_name }}
+          path: dist
+      - name: Publish to Chrome Web Store
+        env:
+          EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+        run: |
+          npx chrome-webstore-upload-cli@3 \
+            --source=./dist/chromium/src

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ scripts/jq
 .pip
 
 .npm_in_container
+
+web-ext-artifacts

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,9 @@ watch:
 graphql_generate:
 	npm run graphql:generate
 
-.PHONY: bump_patch_version
-bump_patch_version:
-	npm version patch
-
-.PHONY: bump_minor_version
-bump_minor_version:
-	npm version minor
-
-.PHONY: bump_major_version
-bump_major_version:
-	npm version major
+.PHONY: bump_version
+bump_version:
+	npm version "$(bump)"
 
 .PHONY: all_in_container
 all_in_container:
@@ -63,14 +55,6 @@ export_pontoon_graphql_schema:
 	CONTAINER_IMAGE='docker.io/library/python:3.11-bookworm' bash ./scripts/run-in-container.sh 'bash ./scripts/export-pontoon-graphql-schema.sh ./src/pontoon.graphql'
 	make graphql_generate_in_container
 
-.PHONY: bump_patch_version_in_container
-bump_patch_version_in_container:
-	bash ./scripts/run-in-container.sh make bump_patch_version
-
-.PHONY: bump_minor_version_in_container
-bump_minor_version_in_container:
-	bash ./scripts/run-in-container.sh make bump_minor_version
-
-.PHONY: bump_major_version_in_container
-bump_major_version_in_container:
-	bash ./scripts/run-in-container.sh make bump_major_version
+.PHONY: bump_version_in_container
+bump_version_in_container:
+	bash ./scripts/run-in-container.sh make bump_version bump="$(bump)"

--- a/amo-metadata.json
+++ b/amo-metadata.json
@@ -1,0 +1,31 @@
+{
+  "categories": [
+    "alerts-updates",
+    "language-support",
+    "other"
+  ],
+  "description": {
+    "en-US": "Pontoon Add-on (formerly Pontoon Tools) eases localizers everyday work with <a href=\"https://pontoon.mozilla.org/\">Pontoon</a>, the Mozilla localization tool.\n\nThis add-on brings <strong>notifications</strong> from Pontoon directly into your browser. It also provides features for <strong>proofreading, bug reporting and fixing</strong>. The introduction tour will show you around right after installation. Version for Chrome <a href=\"https://chrome.google.com/webstore/detail/pontoon-tools/gnbfbnpjncpghhjmmhklfhcglbopagbb\">is now available too</a>.\n\nHave an idea, for something cool? <a href=\"https://github.com/MikkCZ/pontoon-addon/issues\">Let us know on GitHub</a>."
+  },
+  "homepage": {
+    "en-US": "https://github.com/MikkCZ/pontoon-addon/issues"
+  },
+  "name": {
+    "en-US": "Pontoon Add-on"
+  },
+  "slug": "pontoon-tools",
+  "summary": {
+    "en-US": "Tools for Pontoon and its integration into the browser."
+  },
+  "support_email": {
+    "en-US": "mstanke@mozilla.cz"
+  },
+  "version": {
+    "compatibility": [
+      "android",
+      "firefox"
+    ],
+    "license": "BSD-2-Clause",
+    "upload": "pontoon-tools@mikk.cz"
+  }
+}

--- a/configs/webpack.config.ts
+++ b/configs/webpack.config.ts
@@ -250,7 +250,25 @@ export default async function configs(): Promise<Configuration[]> {
               minify: false,
             }),
           ],
-        }
+        },
+        {
+          ...commonConfiguration,
+          name: 'amo-metadata',
+          entry: './package.json', // anything webpack can load by itself
+          output: {
+            ...commonConfiguration.output,
+            // ignore chunk emitted from the entry
+            filename: path.relative(commonConfiguration.output?.path!, '/dev/null'),
+            path: path.resolve(commonConfiguration.output?.path!, '..', '..'),
+          },
+          plugins: [
+            new CopyPlugin({
+              patterns:[
+                { from: 'amo-metadata.json', to: path.resolve(commonConfiguration.output?.path!, '..') },
+              ],
+            }),
+          ],
+        },
       ] : []
     ),
   ];

--- a/scripts/run-in-container.sh
+++ b/scripts/run-in-container.sh
@@ -21,5 +21,7 @@ ${CONTAINER_RUN} \
   --workdir "${PWD}" \
   -e NPM_CONFIG_CACHE="${PWD}/.npm_in_container" \
   -e MODE="${MODE}" \
+  -e WEB_EXT_API_KEY="${WEB_EXT_API_KEY}" \
+  -e WEB_EXT_API_SECRET="${WEB_EXT_API_SECRET}" \
   --entrypoint=/bin/bash \
   "${CONTAINER_IMAGE}" -c "${COMMAND}"


### PR DESCRIPTION
Upload the build add-on to AMO and Chrome Web Store automatically. This is heavily inspired by https://github.com/fregante/ghatemplates/blob/main/webext/release.yml.

fix #121