### PR TITLE
test: report coverage as HTML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           retention-days: 30
       - name: Show code coverage in summary
         run: |
-          summary="$(npx -y tsx scripts/test-coverage-github-summary.ts)"
+          summary="$(npx -y tsx@4 scripts/test-coverage-github-summary.ts)"
           echo "${summary}" >> $GITHUB_STEP_SUMMARY
   generated_code_consistency:
     name: Verify generated code is consistent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,12 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Run tests
         run: make test_in_container
+      - name: Upload code coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+          retention-days: 30
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v4
   generated_code_consistency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,6 @@ jobs:
           name: coverage
           path: coverage
           retention-days: 30
-      - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v4
   generated_code_consistency:
     name: Verify generated code is consistent
     needs: prepare_cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,8 @@ jobs:
           name: coverage
           path: coverage
           retention-days: 30
+      - name: Show code coverage in summary
+        run: npx -y tsx scripts/test-coverage-github-summary.ts
   generated_code_consistency:
     name: Verify generated code is consistent
     needs: prepare_cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           retention-days: 30
       - name: Show code coverage in summary
         run: |
-          summary="${npx -y tsx scripts/test-coverage-github-summary.ts}"
+          summary="$(npx -y tsx scripts/test-coverage-github-summary.ts)"
           echo "${summary}" >> $GITHUB_STEP_SUMMARY
   generated_code_consistency:
     name: Verify generated code is consistent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,17 +103,9 @@ jobs:
           path: coverage
           retention-days: 30
       - name: Show code coverage in summary
-        id: code_coverage_summary
         run: |
           summary="$(npx -y tsx@4 scripts/test-coverage-github-summary.ts)"
           echo "${summary}" >> $GITHUB_STEP_SUMMARY
-          echo "summary=${summary}" >> $GITHUB_OUTPUT
-      - name: Code coverage in the PR comment
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: ${{ steps.code_coverage_summary.outputs.summary }}
-          comment_tag: code_coverage_summary
   generated_code_consistency:
     name: Verify generated code is consistent
     needs: prepare_cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,17 @@ jobs:
           path: coverage
           retention-days: 30
       - name: Show code coverage in summary
+        id: code_coverage_summary
         run: |
           summary="$(npx -y tsx@4 scripts/test-coverage-github-summary.ts)"
           echo "${summary}" >> $GITHUB_STEP_SUMMARY
+          echo "summary=${summary}" >> $GITHUB_OUTPUT
+      - name: Code coverage in the PR comment
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: ${{ steps.code_coverage_summary.outputs.summary }}
+          comment_tag: code_coverage_summary
   generated_code_consistency:
     name: Verify generated code is consistent
     needs: prepare_cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,9 @@ jobs:
           path: coverage
           retention-days: 30
       - name: Show code coverage in summary
-        run: npx -y tsx scripts/test-coverage-github-summary.ts
+        run: |
+          summary="${npx -y tsx scripts/test-coverage-github-summary.ts}"
+          echo "${summary}" >> $GITHUB_STEP_SUMMARY
   generated_code_consistency:
     name: Verify generated code is consistent
     needs: prepare_cache

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pontoon Add-on
 
 [![Build](https://github.com/MikkCZ/pontoon-addon/actions/workflows/build.yml/badge.svg)](https://github.com/MikkCZ/pontoon-addon/actions/workflows/build.yml)
-[![codecov](https://codecov.io/gh/MikkCZ/pontoon-addon/branch/main/graph/badge.svg?token=wV84O1ujms)](https://codecov.io/gh/MikkCZ/pontoon-addon)
 
 [![Mozilla Add-on](https://img.shields.io/amo/v/pontoon-tools.svg?label=Mozilla%20Add-ons&color=informational)](https://addons.mozilla.org/firefox/addon/pontoon-tools/)
 [![Mozilla Add-on](https://img.shields.io/amo/users/pontoon-tools.svg?label=users&color=informational)](https://addons.mozilla.org/firefox/addon/pontoon-tools/statistics/)

--- a/configs/jest.config.ts
+++ b/configs/jest.config.ts
@@ -32,6 +32,7 @@ const config: Config.InitialOptions = {
     '/generated/',
     '.+\\.d.ts$',
   ],
+  coverageReporters: ['clover', 'json', 'lcov', 'html'],
   preset: 'ts-jest',
   transform: {
     '.+\\.jsx?$': ['babel-jest', { presets: [ '@babel/env' ] }],

--- a/configs/jest.config.ts
+++ b/configs/jest.config.ts
@@ -33,6 +33,14 @@ const config: Config.InitialOptions = {
     '.+\\.d.ts$',
   ],
   coverageReporters: ['clover', 'json', 'json-summary', 'lcov', 'html'],
+  coverageThreshold: {
+    global: {
+      lines: 50,
+      statements: 50,
+      functions: 45,
+      branches: 30,
+    },
+  },
   preset: 'ts-jest',
   transform: {
     '.+\\.jsx?$': ['babel-jest', { presets: [ '@babel/env' ] }],

--- a/configs/jest.config.ts
+++ b/configs/jest.config.ts
@@ -32,7 +32,7 @@ const config: Config.InitialOptions = {
     '/generated/',
     '.+\\.d.ts$',
   ],
-  coverageReporters: ['clover', 'json', 'lcov', 'html'],
+  coverageReporters: ['clover', 'json', 'json-summary', 'lcov', 'html'],
   preset: 'ts-jest',
   transform: {
     '.+\\.jsx?$': ['babel-jest', { presets: [ '@babel/env' ] }],

--- a/scripts/test-coverage-github-summary.ts
+++ b/scripts/test-coverage-github-summary.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+
+interface CoverageSummaryItem {
+  total: number,
+  covered: number,
+  skipped: number,
+  pct: number,
+}
+
+interface CoverageSummary {
+  total: {
+    lines: CoverageSummaryItem,
+    statements: CoverageSummaryItem,
+    functions: CoverageSummaryItem,
+    branches: CoverageSummaryItem,
+    branchesTrue: CoverageSummaryItem,
+  },
+}
+
+function formatCoverageDetailName(key: string): string {
+  return key.split(/(?=[A-Z])/)
+    .map(word => word.toLowerCase())
+    .join(' ');
+}
+
+function formatCoveragePct(pct: CoverageSummaryItem['pct']): string {
+  return `${pct.toFixed(2)} %`;
+}
+
+const coverageSummary = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../coverage/coverage-summary.json'), {
+    encoding: 'utf-8',
+  }),
+) as CoverageSummary;
+
+const itemsToAverage: Array<keyof CoverageSummary['total']> = [
+  'lines',
+  'statements',
+  'functions',
+  'branches',
+];
+
+const output = `
+## Code coverage: ${formatCoveragePct(
+  itemsToAverage
+    .map(itemKey => coverageSummary.total[itemKey].pct)
+    .reduce((acc, curr) => acc + curr, 0) / itemsToAverage.length
+)}
+
+### Details:
+${
+Object.entries(coverageSummary.total)
+  .map(([key, {pct}]) => `- ${formatCoverageDetailName(key)}: ${formatCoveragePct(pct)}`)
+  .join('\n')
+}
+`.trim();
+
+process.stdout.write(`${output}\n`);


### PR DESCRIPTION
fix #936

TODO:
- [x] build creates an HTML coverage report
- [x] HTML coverage report is available to download from GitHub job artifacts
- [x] PRs and build contain ~custom~ a check that will pass/fail if the coverage is above/below required threshold
- [x] Codecov is removed from this repository
- [ ] Codecov integration is disabled and secrets removed