### PR TITLE
fix: prevent errors in Chromium console

### DIFF
--- a/configs/jest.setup.ts
+++ b/configs/jest.setup.ts
@@ -1,6 +1,15 @@
+import { TextEncoder, TextDecoder } from 'util'
+import crypto from 'crypto';
+
 import 'mockzilla-webextension';
 import '@testing-library/jest-dom';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en.json';
 
 TimeAgo.addLocale(en);
+
+globalThis.TextEncoder = TextEncoder;
+// @ts-expect-error
+globalThis.TextDecoder = TextDecoder;
+// @ts-expect-error
+globalThis.crypto = crypto;

--- a/configs/webpack.config.ts
+++ b/configs/webpack.config.ts
@@ -96,7 +96,7 @@ const commonFrontendWebpackPluginOptions: HtmlWebpackPlugin.Options = {
   },
 };
 
-const extensionManifestJson = getManifestFor(targetBrowser);
+const extensionManifestJson = getManifestFor(targetBrowser, 2);
 
 export default async function configs(): Promise<Configuration[]> {
   const { default: WebExtPlugin } = await import('web-ext-plugin');

--- a/src/background/RemotePontoon.ts
+++ b/src/background/RemotePontoon.ts
@@ -10,7 +10,7 @@ import {
   saveToStorage,
 } from '@commons/webExtensionsApi';
 import { pontoonSettings, pontoonTeamsList } from '@commons/webLinks';
-import { getOneOption } from '@commons/options';
+import { getOneOption, resetDefaultOptions, setOption } from '@commons/options';
 
 import {
   AUTOMATION_UTM_SOURCE,
@@ -84,6 +84,26 @@ export function initMessageListeners() {
       return await getUsersTeamFromPontoon();
     },
   );
+  listenToMessagesAndRespond<'RESET_DEFAULT_OPTIONS'>(
+    'reset-default-options',
+    async () => {
+      await resetDefaultOptions();
+      await initOptions();
+      return {
+        type: 'default-options-reset',
+      };
+    },
+  );
+}
+
+export async function initOptions() {
+  const localeTeamOption = await getOneOption('locale_team');
+  if (typeof localeTeamOption !== 'string') {
+    const teamFromPontoon = await getUsersTeamFromPontoon();
+    if (typeof teamFromPontoon === 'string') {
+      await setOption('locale_team', teamFromPontoon);
+    }
+  }
 }
 
 export async function refreshData(context: {

--- a/src/background/contextMenu.ts
+++ b/src/background/contextMenu.ts
@@ -40,24 +40,29 @@ export function init() {
 async function createContextMenuItems() {
   const [
     { pontoon_base_url: pontoonBaseUrl, locale_team: teamCode },
-    { projectsList: projects, teamsList },
+    { projectsList, teamsList },
   ] = await Promise.all([
     getOptions(['pontoon_base_url', 'locale_team']),
     getFromStorage(['projectsList', 'teamsList']),
   ]);
-  if (projects && teamsList) {
+  if (
+    typeof projectsList === 'object' &&
+    Object.values(projectsList).length > 0 &&
+    typeof teamsList === 'object' &&
+    typeof teamsList[teamCode] === 'object'
+  ) {
     const team = teamsList[teamCode];
 
     const parentContextMenuId = await recreateContextMenu({
       id: 'page-context-menu-parent',
       title: 'Pontoon Add-on',
-      documentUrlPatterns: Object.values(projects)
+      documentUrlPatterns: Object.values(projectsList)
         .flatMap((project) => project.domains)
         .map((domain) => `https://${domain}/*`),
       contexts: [...NON_SELECTION_CONTEXTS, ...SELECTION_CONTEXTS],
     });
 
-    for (const project of Object.values(projects)) {
+    for (const project of Object.values(projectsList)) {
       for (const item of contextMenuItemsForProject(
         project,
         team,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@commons/webExtensionsApi';
 
 import { init as initPontoonHttpClient } from './httpClients/pontoonHttpClient';
-import { initMessageListeners } from './RemotePontoon';
+import { initMessageListeners, initOptions } from './RemotePontoon';
 import { init as initSystemNotifications } from './systemNotifications';
 import { init as initToolbarButton } from './toolbarButton';
 import { init as init } from './addressBarIcon';
@@ -20,6 +20,7 @@ import { init as initDataRefresh } from './dataRefresh';
 
 initPontoonHttpClient();
 initMessageListeners();
+initOptions();
 
 // native system
 initSystemNotifications();

--- a/src/commons/backgroundMessaging/index.ts
+++ b/src/commons/backgroundMessaging/index.ts
@@ -37,6 +37,14 @@ export type BackgroundMessagesWithResponse = {
         | BackgroundMessagesWithoutResponse['DISABLE_NOTIFICATIONS_BELL_SCRIPT']['message']['type'];
     };
   };
+  RESET_DEFAULT_OPTIONS: {
+    message: {
+      type: 'reset-default-options';
+    };
+    response: {
+      type: 'default-options-reset';
+    };
+  };
 };
 
 export type BackgroundMessagesWithoutResponse = {
@@ -165,5 +173,11 @@ export async function reportTranslatedTextToBugzilla(text: string) {
 export async function notificationBellIconScriptLoaded() {
   return await sendMessage<'NOTIFICATIONS_BELL_SCRIPT_LOADED'>({
     type: 'notifications-bell-script-loaded',
+  });
+}
+
+export async function resetDefaultOptions() {
+  return await sendMessage<'RESET_DEFAULT_OPTIONS'>({
+    type: 'reset-default-options',
   });
 }

--- a/src/commons/data/__mocks__/defaultOptions.ts
+++ b/src/commons/data/__mocks__/defaultOptions.ts
@@ -1,0 +1,3 @@
+export const coalesceLegacyValues = (_: unknown, value: unknown) => value;
+
+export const defaultOptionsFor = jest.fn();

--- a/src/commons/data/defaultOptions.ts
+++ b/src/commons/data/defaultOptions.ts
@@ -7,24 +7,27 @@ export interface OptionsContent {
   toolbar_button_action: 'popup' | 'team-page';
   toolbar_button_popup_always_hide_read_notifications: boolean;
   show_notifications: boolean;
-  contextual_identity: string;
+  contextual_identity: string | undefined;
   pontoon_base_url: string;
 }
 
-const generalDefaultOptions: Omit<OptionsContent, 'contextual_identity'> = {
-  locale_team: browser.i18n.getUILanguage(),
-  pontoon_base_url: DEFAULT_PONTOON_BASE_URL,
+const generalDefaultOptions: OptionsContent = {
+  locale_team: browser?.i18n?.getUILanguage() ?? undefined, // no fallback e.g. for content scripts
   data_update_interval: 15,
   toolbar_button_action: 'popup',
   toolbar_button_popup_always_hide_read_notifications: false,
   show_notifications: true,
+  contextual_identity: undefined,
+  pontoon_base_url: DEFAULT_PONTOON_BASE_URL,
 };
 
 export function coalesceLegacyValues<K extends keyof OptionsContent>(
   id: K,
   value: OptionsContent[K],
 ): OptionsContent[K] {
-  if (id === 'toolbar_button_action' && value === 'home-page') {
+  if (id === 'locale_team' && typeof value === 'undefined') {
+    return browser.i18n.getUILanguage() as OptionsContent[K];
+  } else if (id === 'toolbar_button_action' && value === 'home-page') {
     return 'team-page' as OptionsContent[K];
   } else {
     return value;

--- a/src/commons/options.spec.ts
+++ b/src/commons/options.spec.ts
@@ -7,14 +7,13 @@ import {
   resetDefaultOptions,
   setOption,
 } from './options';
+import { defaultOptionsFor } from './data/defaultOptions';
 
 jest.mock('@commons/webExtensionsApi/browser');
+jest.mock('@commons/data/defaultOptions');
 
-jest.mock('./data/defaultOptions', () => ({
-  defaultOptionsFor: () => ({
-    locale_team: 'en',
-  }),
-  coalesceLegacyValues: (_: unknown, value: unknown) => value,
+(defaultOptionsFor as jest.Mock).mockImplementation(() => ({
+  locale_team: 'en',
 }));
 
 beforeEach(() => {

--- a/src/commons/utils.ts
+++ b/src/commons/utils.ts
@@ -9,7 +9,7 @@ export async function hash(
   algorithm: AlgorithmIdentifier = 'SHA-256',
 ): Promise<string> {
   const inputBytes = textEncoder.encode(input);
-  const hashBytes = await window.crypto.subtle.digest(algorithm, inputBytes);
+  const hashBytes = await crypto.subtle.digest(algorithm, inputBytes);
   return textDecoder.decode(hashBytes);
 }
 

--- a/src/commons/utils.ts
+++ b/src/commons/utils.ts
@@ -1,6 +1,18 @@
 import { supportsContainers } from './webExtensionsApi';
 import { getOneOption } from './options';
 
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export async function hash(
+  input: string,
+  algorithm: AlgorithmIdentifier = 'SHA-256',
+): Promise<string> {
+  const inputBytes = textEncoder.encode(input);
+  const hashBytes = await window.crypto.subtle.digest(algorithm, inputBytes);
+  return textDecoder.decode(hashBytes);
+}
+
 export async function openNewPontoonTab(url: string) {
   return browser.tabs.create({
     url,

--- a/src/commons/webExtensionsApi/index.ts
+++ b/src/commons/webExtensionsApi/index.ts
@@ -265,21 +265,23 @@ export async function registerScriptForBaseUrl(
   baseUrl: string,
   file: string,
 ): Promise<void> {
-  if (typeof browser.scripting?.registerContentScripts === 'function') {
-    return await browser.scripting.registerContentScripts([
+  const matches = [`${baseUrl}/*`];
+  const runAt = 'document_end'; // Corresponds to interactive. The DOM has finished loading, but resources such as scripts and images may still be loading.
+  if (typeof browser.contentScripts?.register === 'function') {
+    await browser.contentScripts.register({
+      js: [{ file }],
+      matches,
+      runAt,
+    });
+  } else if (typeof browser.scripting?.registerContentScripts === 'function') {
+    await browser.scripting.registerContentScripts([
       {
         id: await hash(`${baseUrl}_${file}`),
         js: [file],
-        matches: [`${baseUrl}/*`],
-        runAt: 'document_end', // Corresponds to interactive. The DOM has finished loading, but resources such as scripts and images may still be loading.
+        matches,
+        runAt,
       },
     ]);
-  } else if (typeof browser.contentScripts?.register === 'function') {
-    await browser.contentScripts.register({
-      js: [{ file }],
-      matches: [`${baseUrl}/*`],
-      runAt: 'document_end', // Corresponds to interactive. The DOM has finished loading, but resources such as scripts and images may still be loading.
-    });
   } else {
     console.error(`No extension API found to register content scripts.`);
   }

--- a/src/commons/webExtensionsApi/spec.ts
+++ b/src/commons/webExtensionsApi/spec.ts
@@ -3,6 +3,8 @@ import type { MockzillaDeep } from 'mockzilla';
 import type { Alarms, ExtensionTypes, Tabs } from 'webextension-polyfill';
 import 'mockzilla-webextension';
 
+import { hash } from '@commons/utils';
+
 import {
   browser,
   browserFamily,
@@ -260,13 +262,16 @@ describe('webExtensionsApi', () => {
   });
 
   it('registerScriptForBaseUrl', async () => {
-    mockBrowser.contentScripts.register
-      .expect({
-        js: [{ file: 'foo/bar.js' }],
-        matches: ['https://localhost/*'],
-        runAt: 'document_end',
-      })
-      .andResolve({ unregister: jest.fn() });
+    mockBrowser.scripting.registerContentScripts
+      .expect([
+        {
+          id: await hash('https://localhost/*_foo/bar.js'),
+          js: ['foo/bar.js'],
+          matches: ['https://localhost/*'],
+          runAt: 'document_end',
+        },
+      ])
+      .andResolve();
 
     await registerScriptForBaseUrl('https://localhost', 'foo/bar.js');
   });

--- a/src/commons/webExtensionsApi/spec.ts
+++ b/src/commons/webExtensionsApi/spec.ts
@@ -3,7 +3,7 @@ import type { MockzillaDeep } from 'mockzilla';
 import type { Alarms, ExtensionTypes, Tabs } from 'webextension-polyfill';
 import 'mockzilla-webextension';
 
-import { hash } from '@commons/utils';
+import { defaultOptionsFor } from '../data/defaultOptions';
 
 import {
   browser,
@@ -42,6 +42,11 @@ import {
 } from '.';
 
 jest.mock('@commons/webExtensionsApi/browser');
+jest.mock('@commons/data/defaultOptions');
+
+(defaultOptionsFor as jest.Mock).mockImplementation(() => ({
+  locale_team: 'en',
+}));
 
 describe('webExtensionsApi', () => {
   it('exports browser', () => {
@@ -262,16 +267,13 @@ describe('webExtensionsApi', () => {
   });
 
   it('registerScriptForBaseUrl', async () => {
-    mockBrowser.scripting.registerContentScripts
-      .expect([
-        {
-          id: await hash('https://localhost/*_foo/bar.js'),
-          js: ['foo/bar.js'],
-          matches: ['https://localhost/*'],
-          runAt: 'document_end',
-        },
-      ])
-      .andResolve();
+    mockBrowser.contentScripts.register
+      .expect({
+        js: [{ file: 'foo/bar.js' }],
+        matches: ['https://localhost/*'],
+        runAt: 'document_end',
+      })
+      .andResolve({ unregister: jest.fn() });
 
     await registerScriptForBaseUrl('https://localhost', 'foo/bar.js');
   });

--- a/src/content-scripts/context-buttons.ts
+++ b/src/content-scripts/context-buttons.ts
@@ -10,9 +10,9 @@ const contextButtonWidth = 24;
 
 function getSelectedText(): string {
   if (window.getSelection) {
-    return window.getSelection()?.toString() || '';
+    return window.getSelection()?.toString().trim() || '';
   } else if (document.getSelection) {
-    return document.getSelection()?.toString() || '';
+    return document.getSelection()?.toString().trim() || '';
   } else {
     return '';
   }
@@ -53,8 +53,8 @@ allContextButtons.forEach((button) => {
 document.addEventListener('mouseup', (e) => {
   const selectedText = getSelectedText();
   if (selectedText.length > 0) {
-    pontoonSearchButton.title = `Search for "${selectedText.trim()}" in translations of all projects`;
-    bugzillaReportButton.title = `Report l10n bug for "${selectedText.trim()}"`;
+    pontoonSearchButton.title = `Search for "${selectedText}" in translations of all projects`;
+    bugzillaReportButton.title = `Report l10n bug for "${selectedText}"`;
 
     const yCoord = window.scrollY + e.screenY - 120;
     let xCoord = e.screenX + 6;
@@ -65,6 +65,8 @@ document.addEventListener('mouseup', (e) => {
     });
     allContextButtons.forEach((button) => document.body.appendChild(button));
   } else {
-    allContextButtons.forEach((button) => document.body.removeChild(button));
+    allContextButtons
+      .filter((button) => button.parentElement || button.parentNode)
+      .forEach((button) => document.body.removeChild(button));
   }
 });

--- a/src/frontend/options/App/index.tsx
+++ b/src/frontend/options/App/index.tsx
@@ -7,13 +7,13 @@ import {
   openPrivacyPolicy,
   supportsContainers,
 } from '@commons/webExtensionsApi';
-import { resetDefaultOptions } from '@commons/options';
 import { pontoonAddonWiki } from '@commons/webLinks';
 import { colors } from '@frontend/commons/const';
 import { Page } from '@frontend/commons/components/pontoon/Page';
 import { Heading1 } from '@frontend/commons/components/pontoon/Heading1';
 import { Heading3 } from '@frontend/commons/components/pontoon/Heading3';
 import { Link } from '@frontend/commons/components/pontoon/Link';
+import { resetDefaultOptions } from '@commons/backgroundMessaging';
 
 import { LocaleSelection } from '../LocaleSelection';
 import { DataIntervalUpdateSelection } from '../DataIntervalUpdateSelection';

--- a/src/manifest.json.ts
+++ b/src/manifest.json.ts
@@ -64,6 +64,7 @@ const pontoonLogo128Png = 'assets/img/pontoon-logo-128.png';
 // ts-prune-ignore-next
 export function getManifestFor(
   targetBrowser: BrowserFamily,
+  manifestVersion: 2 | 3,
 ): Record<string, unknown> {
   const forMozilla = targetBrowser === BrowserFamily.MOZILLA;
   const forChromium = targetBrowser === BrowserFamily.CHROMIUM;
@@ -96,7 +97,7 @@ export function getManifestFor(
           ),
         }
       : {}),
-    manifest_version: 2,
+    manifest_version: manifestVersion,
     name: 'Pontoon Add-on',
     description: packageJson.description,
     version: packageJson.version,
@@ -124,6 +125,7 @@ export function getManifestFor(
       'tabs',
       'notifications',
       'alarms',
+      ...(manifestVersion === 3 ? ['scripting'] : []),
       ...(forMozilla
         ? [
             'contextualIdentities',


### PR DESCRIPTION
fix #941

Prepare for scripting API in manifest V3. Correct how context menus are created. Improve initialization after install or when no options were selected or data loaded yet. Remove errors when content scripts which do not have access to browser.i18n API.