### PR TITLE
chore: replace mockzilla by Jest mocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,6 @@ updates:
           - "@testing-library/*"
           - "@types/jest"
           - "*jest*"
-          - "mockzilla*"
         exclude-patterns:
           - "*eslint*"
       typescript:

--- a/configs/jest.config.ts
+++ b/configs/jest.config.ts
@@ -16,6 +16,9 @@ const textFilesModuleNameMapper = {
 const config: Config.InitialOptions = {
   rootDir,
   testEnvironment: 'jsdom',
+  setupFiles: [
+    'jest-webextension-mock',
+  ],
   setupFilesAfterEnv: [
     path.resolve(__dirname, 'jest.setup.ts'),
     'jest-canvas-mock', // only for 'react-game-snake'

--- a/configs/jest.setup.ts
+++ b/configs/jest.setup.ts
@@ -1,7 +1,7 @@
 import { TextEncoder, TextDecoder } from 'util'
 import crypto from 'crypto';
 
-import 'mockzilla-webextension';
+import 'jest-webextension-mock';
 import '@testing-library/jest-dom';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en.json';

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,10 +71,9 @@
         "jest-canvas-mock": "^2.5.2",
         "jest-environment-jsdom": "^29.7.0",
         "jest-transform-stub": "^2.0.0",
+        "jest-webextension-mock": "^3.9.0",
         "markdown-loader": "^8.0.0",
         "mini-css-extract-plugin": "^2.9.1",
-        "mockzilla": "^0.14.0",
-        "mockzilla-webextension": "^0.15.0",
         "npm-run-all": "^4.1.5",
         "package-json-type": "^1.0.3",
         "postcss-styled-syntax": "^0.6.4",
@@ -14297,6 +14296,13 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-webextension-mock": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.9.0.tgz",
+      "integrity": "sha512-cknPFLO3cD2GwsgpVWwcsW+s2CoKKsEHCDNDw1ZNrA5+9R28/g4UOC2CEPc+Z+MwvoNjvIsEsowJy7L6MldBYg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jest-worker": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
@@ -15264,32 +15270,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mockzilla": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/mockzilla/-/mockzilla-0.14.0.tgz",
-      "integrity": "sha512-vkRwyJaAAeTj6oH9NHUDELhUCwTCYleLZoNmo4+o08/hoUGn7tle3yZjp3Q4ZQ2HUEEFwpGJh50ZFMWWhLgI5Q==",
-      "dev": true,
-      "peerDependencies": {
-        "@jest/expect-utils": "^28.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^28.0.0",
-        "jest-diff": "^28.0.0",
-        "jest-message-util": "^28.0.0",
-        "jest-validate": "^28.0.0"
-      }
-    },
-    "node_modules/mockzilla-webextension": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/mockzilla-webextension/-/mockzilla-webextension-0.15.0.tgz",
-      "integrity": "sha512-gnyHsk41jEsVgmsLomceOXJV9vxMF3e3B9ltQbWVCSvaVjz5o/+5gzHn0c5Y62NkRAnVOz3cRA7tZq0ZhKJ+Qg==",
-      "dev": true,
-      "peerDependencies": {
-        "@types/jest": "^28.0.0",
-        "jest": "^28.0.0",
-        "mockzilla": "^0.14.0",
-        "webextension-polyfill": "^0.9.0"
       }
     },
     "node_modules/moo-color": {
@@ -31168,6 +31148,12 @@
         "string-length": "^4.0.1"
       }
     },
+    "jest-webextension-mock": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.9.0.tgz",
+      "integrity": "sha512-cknPFLO3cD2GwsgpVWwcsW+s2CoKKsEHCDNDw1ZNrA5+9R28/g4UOC2CEPc+Z+MwvoNjvIsEsowJy7L6MldBYg==",
+      "dev": true
+    },
     "jest-worker": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
@@ -31893,20 +31879,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
-    },
-    "mockzilla": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/mockzilla/-/mockzilla-0.14.0.tgz",
-      "integrity": "sha512-vkRwyJaAAeTj6oH9NHUDELhUCwTCYleLZoNmo4+o08/hoUGn7tle3yZjp3Q4ZQ2HUEEFwpGJh50ZFMWWhLgI5Q==",
-      "dev": true,
-      "requires": {}
-    },
-    "mockzilla-webextension": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/mockzilla-webextension/-/mockzilla-webextension-0.15.0.tgz",
-      "integrity": "sha512-gnyHsk41jEsVgmsLomceOXJV9vxMF3e3B9ltQbWVCSvaVjz5o/+5gzHn0c5Y62NkRAnVOz3cRA7tZq0ZhKJ+Qg==",
-      "dev": true,
-      "requires": {}
     },
     "moo-color": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -94,10 +94,9 @@
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
     "jest-transform-stub": "^2.0.0",
+    "jest-webextension-mock": "^3.9.0",
     "markdown-loader": "^8.0.0",
     "mini-css-extract-plugin": "^2.9.1",
-    "mockzilla": "^0.14.0",
-    "mockzilla-webextension": "^0.15.0",
     "npm-run-all": "^4.1.5",
     "package-json-type": "^1.0.3",
     "postcss-styled-syntax": "^0.6.4",
@@ -113,11 +112,6 @@
     "web-ext-plugin": "^2.10.0",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4"
-  },
-  "overrides": {
-    "mockzilla-webextension": {
-      "webextension-polyfill": "^0.12.0"
-    }
   },
   "engines": {
     "node": "^20",

--- a/src/commons/backgroundMessaging/spec.ts
+++ b/src/commons/backgroundMessaging/spec.ts
@@ -1,7 +1,4 @@
 /* eslint-disable jest/expect-expect */
-import type { MockzillaDeep } from 'mockzilla';
-import 'mockzilla-webextension';
-
 import { getOneOption } from '../options';
 
 import type { BackgroundMessage } from '.';
@@ -20,7 +17,6 @@ import {
   updateTeamsList,
 } from '.';
 
-jest.mock('@commons/webExtensionsApi/browser');
 jest.mock('@commons/options');
 
 (getOneOption as jest.Mock).mockImplementation((key: string) => {
@@ -37,14 +33,6 @@ jest.mock('@commons/options');
 afterEach(() => {
   jest.clearAllMocks();
 });
-
-function mockBrowserSendMessage<T extends keyof BackgroundMessage>() {
-  return mockBrowser.runtime.sendMessage as unknown as MockzillaDeep<{
-    (
-      message: BackgroundMessage[T]['message'],
-    ): Promise<BackgroundMessage[T]['response']>;
-  }>;
-}
 
 describe('messagingClient', () => {
   it('getNotificationsUrl', async () => {
@@ -90,23 +78,27 @@ describe('messagingClient', () => {
         },
       },
     };
-    mockBrowserSendMessage<'UPDATE_TEAMS_LIST'>()
-      .expect({ type: 'update-teams-list' })
-      .andResolve(mockTeamsList);
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce(
+      mockTeamsList,
+    );
 
     const teams = await updateTeamsList();
 
     expect(teams).toStrictEqual(mockTeamsList);
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'update-teams-list',
+    });
   });
 
   it('getUsersTeamFromPontoon', async () => {
-    mockBrowserSendMessage<'GET_TEAM_FROM_PONTOON'>()
-      .expect({ type: 'get-team-from-pontoon' })
-      .andResolve('cs');
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce('cs');
 
     const team = await getUsersTeamFromPontoon();
 
     expect(team).toBe('cs');
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'get-team-from-pontoon',
+    });
   });
 
   it('getPontoonProjectForTheCurrentTab', async () => {
@@ -116,70 +108,73 @@ describe('messagingClient', () => {
         name: 'Firefox',
         domains: [],
       };
-    mockBrowserSendMessage<'GET_CURRENT_TAB_PROJECT'>()
-      .expect({ type: 'get-current-tab-project' })
-      .andResolve(mockProject);
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce(
+      mockProject,
+    );
 
     const project = await getPontoonProjectForTheCurrentTab();
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(project).toStrictEqual(mockProject);
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'get-current-tab-project',
+    });
   });
 
   it('pageLoaded', async () => {
-    mockBrowserSendMessage<'PAGE_LOADED'>()
-      .expect({
-        type: 'pontoon-page-loaded',
-        documentHTML: '<html></html>',
-      })
-      .andResolve();
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce(undefined);
 
     await pageLoaded('<html></html>');
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'pontoon-page-loaded',
+      documentHTML: '<html></html>',
+    });
   });
 
   it('markAllNotificationsAsRead', async () => {
-    mockBrowserSendMessage<'NOTIFICATIONS_READ'>()
-      .expect({ type: 'notifications-read' })
-      .andResolve();
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce(undefined);
 
     await markAllNotificationsAsRead();
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'notifications-read',
+    });
   });
 
   it('searchTextInPontoon', async () => {
-    mockBrowserSendMessage<'SEARCH_TEXT_IN_PONTOON'>()
-      .expect({
-        type: 'search-text-in-pontoon',
-        text: 'foo bar',
-      })
-      .andResolve();
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce(undefined);
 
     await searchTextInPontoon('foo bar');
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'search-text-in-pontoon',
+      text: 'foo bar',
+    });
   });
 
   it('reportTranslatedTextToBugzilla', async () => {
-    mockBrowserSendMessage<'REPORT_TRANSLATED_TEXT_TO_BUGZILLA'>()
-      .expect({
-        type: 'report-translated-text-to-bugzilla',
-        text: 'foo bar',
-      })
-      .andResolve();
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce(undefined);
 
     await reportTranslatedTextToBugzilla('foo bar');
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'report-translated-text-to-bugzilla',
+      text: 'foo bar',
+    });
   });
 
   it('notificationBellIconScriptLoaded', async () => {
-    mockBrowserSendMessage<'NOTIFICATIONS_BELL_SCRIPT_LOADED'>()
-      .expect({
-        type: 'notifications-bell-script-loaded',
-      })
-      .andResolve({
-        type: 'enable-notifications-bell-script',
-      });
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce({
+      type: 'enable-notifications-bell-script',
+    });
 
     const response = await notificationBellIconScriptLoaded();
 
     expect(response).toStrictEqual({
       type: 'enable-notifications-bell-script',
+    });
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'notifications-bell-script-loaded',
     });
   });
 });

--- a/src/commons/options.spec.ts
+++ b/src/commons/options.spec.ts
@@ -1,6 +1,4 @@
 /* eslint-disable jest/expect-expect */
-import 'mockzilla-webextension';
-
 import {
   getOneOption,
   getOptions,
@@ -9,71 +7,80 @@ import {
 } from './options';
 import { defaultOptionsFor } from './data/defaultOptions';
 
-jest.mock('@commons/webExtensionsApi/browser');
 jest.mock('@commons/data/defaultOptions');
 
-(defaultOptionsFor as jest.Mock).mockImplementation(() => ({
-  locale_team: 'en',
-}));
+(defaultOptionsFor as jest.Mock).mockReturnValue({ locale_team: 'en' });
 
 beforeEach(() => {
-  mockBrowser.runtime.getURL.mock(() => 'moz-extension://');
+  (browser.runtime.getURL as jest.Mock).mockReturnValue('moz-extension://');
 });
 
 describe('options', () => {
   it('setOption', async () => {
-    mockBrowser.storage.local.set
-      .expect({ 'options.locale_team': 'cs' })
-      .andResolve();
+    (browser.storage.local.set as jest.Mock).mockResolvedValueOnce(undefined);
 
     await setOption('locale_team', 'cs');
+
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
+      'options.locale_team': 'cs',
+    });
   });
 
   it('getOptions', async () => {
-    mockBrowser.storage.local.get
-      .expect(['options.locale_team'])
-      .andResolve({ 'options.locale_team': 'cs' });
+    (browser.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      'options.locale_team': 'cs',
+    });
 
     const { locale_team } = await getOptions(['locale_team']);
 
     expect(locale_team).toBe('cs');
+    expect(browser.storage.local.get).toHaveBeenCalledWith([
+      'options.locale_team',
+    ]);
   });
 
   it('getOptions loads default', async () => {
-    mockBrowser.storage.local.get
-      .expect(['options.locale_team'])
-      .andResolve({});
+    (browser.storage.local.get as jest.Mock).mockResolvedValueOnce({});
 
     const { locale_team } = await getOptions(['locale_team']);
 
     expect(locale_team).toBe('en');
+    expect(browser.storage.local.get).toHaveBeenCalledWith([
+      'options.locale_team',
+    ]);
   });
 
   it('getOneOption', async () => {
-    mockBrowser.storage.local.get
-      .expect(['options.locale_team'])
-      .andResolve({ 'options.locale_team': 'cs' });
+    (browser.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      'options.locale_team': 'cs',
+    });
 
     const locale_team = await getOneOption('locale_team');
 
     expect(locale_team).toBe('cs');
+    expect(browser.storage.local.get).toHaveBeenCalledWith([
+      'options.locale_team',
+    ]);
   });
 
   it('getOneOption loads default', async () => {
-    mockBrowser.storage.local.get
-      .expect(['options.locale_team'])
-      .andResolve({});
+    (browser.storage.local.get as jest.Mock).mockResolvedValueOnce({});
 
     const locale_team = await getOneOption('locale_team');
 
     expect(locale_team).toBe('en');
+    expect(browser.storage.local.get).toHaveBeenCalledWith([
+      'options.locale_team',
+    ]);
   });
 
   it('resetDefaultOptions', async () => {
-    mockBrowser.storage.local.set
-      .expect(expect.objectContaining({ 'options.locale_team': 'en' }))
-      .andResolve();
+    (browser.storage.local.set as jest.Mock).mockResolvedValueOnce(undefined);
 
     await resetDefaultOptions();
+
+    expect(browser.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({ 'options.locale_team': 'en' }),
+    );
   });
 });

--- a/src/commons/webExtensionsApi/__mocks__/browser.ts
+++ b/src/commons/webExtensionsApi/__mocks__/browser.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-export default require('webextension-polyfill');

--- a/src/commons/webExtensionsApi/__mocks__/index.ts
+++ b/src/commons/webExtensionsApi/__mocks__/index.ts
@@ -1,4 +1,4 @@
-import { default as browserObj } from './browser';
+import { default as browserObj } from '../browser';
 
 export const browser = browserObj;
 

--- a/src/frontend/toolbar-button/NotificationsList/spec.tsx
+++ b/src/frontend/toolbar-button/NotificationsList/spec.tsx
@@ -11,7 +11,6 @@ import {
 
 import { NotificationsList } from '.';
 
-jest.mock('@commons/webExtensionsApi/browser');
 jest.mock('@commons/options');
 jest.mock('@commons/backgroundMessaging');
 

--- a/src/frontend/toolbar-button/NotificationsListError/spec.tsx
+++ b/src/frontend/toolbar-button/NotificationsListError/spec.tsx
@@ -8,7 +8,6 @@ import { getSignInURL } from '@commons/backgroundMessaging';
 
 import { NotificationsListError } from '.';
 
-jest.mock('@commons/webExtensionsApi/browser');
 jest.mock('@commons/options');
 jest.mock('@commons/backgroundMessaging');
 

--- a/src/frontend/toolbar-button/NotificationsListItem/spec.tsx
+++ b/src/frontend/toolbar-button/NotificationsListItem/spec.tsx
@@ -8,7 +8,6 @@ import { getTeamProjectUrl } from '@commons/backgroundMessaging';
 
 import { NotificationsListItem } from '.';
 
-jest.mock('@commons/webExtensionsApi/browser');
 jest.mock('@commons/options');
 jest.mock('@commons/backgroundMessaging');
 


### PR DESCRIPTION
Currently does not work, since not all APIs are covered:
- https://github.com/RickyMarou/jest-webextension-mock/issues/4
- https://github.com/RickyMarou/jest-webextension-mock/issues/11
- https://github.com/RickyMarou/jest-webextension-mock/issues/12
- https://github.com/RickyMarou/jest-webextension-mock/issues/13
- https://github.com/RickyMarou/jest-webextension-mock/issues/14