### PR TITLE
Fix undefined locale error

### DIFF
--- a/src/background/RemotePontoon.ts
+++ b/src/background/RemotePontoon.ts
@@ -2,6 +2,7 @@ import URI from 'urijs';
 
 import type { StorageContent } from '@commons/webExtensionsApi';
 import {
+  browser,
   deleteFromStorage,
   getActiveTab,
   getOneFromStorage,
@@ -101,10 +102,12 @@ export function initMessageListeners() {
 
 export async function initOptions() {
   const localeTeamOption = await getOneOption('locale_team');
-  if (typeof localeTeamOption !== 'string') {
+  if (localeTeamOption === '') {
     const teamFromPontoon = await getUsersTeamFromPontoon();
     if (typeof teamFromPontoon === 'string') {
       await setOption('locale_team', teamFromPontoon);
+    } else {
+      await setOption('locale_team', browser.i18n.getUILanguage());
     }
   }
 

--- a/src/commons/data/defaultOptions.ts
+++ b/src/commons/data/defaultOptions.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PONTOON_BASE_URL } from '../../const';
-import { browser, BrowserFamily } from '../webExtensionsApi';
+import { BrowserFamily } from '../webExtensionsApi';
 
 export interface OptionsContent {
   locale_team: string;
@@ -12,7 +12,7 @@ export interface OptionsContent {
 }
 
 const generalDefaultOptions: OptionsContent = {
-  locale_team: browser?.i18n?.getUILanguage() ?? undefined, // no fallback e.g. for content scripts
+  locale_team: '',
   data_update_interval: 15,
   toolbar_button_action: 'popup',
   toolbar_button_popup_always_hide_read_notifications: false,
@@ -26,7 +26,7 @@ export function coalesceLegacyValues<K extends keyof OptionsContent>(
   value: OptionsContent[K],
 ): OptionsContent[K] {
   if (id === 'locale_team' && typeof value === 'undefined') {
-    return browser.i18n.getUILanguage() as OptionsContent[K];
+    return '' as OptionsContent[K];
   } else if (id === 'toolbar_button_action' && value === 'home-page') {
     return 'team-page' as OptionsContent[K];
   } else {


### PR DESCRIPTION
This PR fixes #1106. It calls `browser.i18n.getUILanguage()` in a background script instead of in `/commons`.
Before, users just installing the addon were unable to access any default locale based on their i18n preset, which based on the intention of the previous code, should have loaded a locale based on their browser. Now, users are guaranteed to have a fallback locale in the event that their Pontoon Hompage locale does not load, or they are installing the addon.